### PR TITLE
Pass flat layers array to the `CoordinateInfo`

### DIFF
--- a/src/components/ToolMenu/FeatureInfo/index.tsx
+++ b/src/components/ToolMenu/FeatureInfo/index.tsx
@@ -9,6 +9,8 @@ import {
   useTranslation
 } from 'react-i18next';
 
+import MapUtil from '@terrestris/ol-util/dist/MapUtil/MapUtil';
+
 import CoordinateInfo, {
   CoordinateInfoState,
   CoordinateInfoProps
@@ -42,7 +44,7 @@ export const FeatureInfo: React.FC<FeatureInfoProps> = ({
     return <></>;
   }
 
-  const getQueryLayers = map.getLayers().getArray()
+  const getQueryLayers = MapUtil.getAllLayers(map)
     .filter((layer) => {
       if (!layer.get('hoverable')) {
         return false;


### PR DESCRIPTION
This suggests to pass the flat list of layers to the `CoordinateInfo` as the internal filter didn't check for group layer contents.

Please review @KaiVolland.