### PR TITLE
Introduce client configuration file

### DIFF
--- a/resources/public/fallbackConfig.js
+++ b/resources/public/fallbackConfig.js
@@ -1,0 +1,3 @@
+var clientConfig = {
+  appPrefix: '/'
+};

--- a/resources/public/fallbackConfig.js
+++ b/resources/public/fallbackConfig.js
@@ -1,3 +1,0 @@
-var clientConfig = {
-  appPrefix: '/'
-};

--- a/resources/public/index.ejs
+++ b/resources/public/index.ejs
@@ -85,6 +85,7 @@
     <script>
       if (!window.clientConfig) {
         console.warn('No config found, client defaults will be used.');
+        window.clientConfig = {};
       }
     </script>
     <div id="app" class="app"></div>

--- a/resources/public/index.ejs
+++ b/resources/public/index.ejs
@@ -80,6 +80,13 @@
     <noscript>
       You need to enable JavaScript to run this app.
     </noscript>
+    <script src="/config/clientConfig.js"></script>
+    <script>
+      if (!window.clientConfig) {
+        console.warn('No config found, loading fallback from ./fallbackConfig.js.');
+        document.write('<script src="./fallbackConfig.js">\x3C/script>')
+      }
+    </script>
     <div id="app" class="app"></div>
   </body>
 </html>

--- a/resources/public/index.ejs
+++ b/resources/public/index.ejs
@@ -9,6 +9,7 @@
       <meta name="_csrf_header" content="<%= htmlWebpackPlugin.options.csrf.csrfHeader %>" />
       <meta name="_csrf_parameter_name" content="<%= htmlWebpackPlugin.options.csrf.csrfParameterName %>" />
     <% } %>
+    <!-- TODO Check if needed -->
     <base href="<%= htmlWebpackPlugin.options.appPrefix %>">
     <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
     <div id="loadmask" class="loadmask">
@@ -83,8 +84,7 @@
     <script src="/config/clientConfig.js"></script>
     <script>
       if (!window.clientConfig) {
-        console.warn('No config found, loading fallback from ./fallbackConfig.js.');
-        document.write('<script src="./fallbackConfig.js">\x3C/script>')
+        console.warn('No config found, client defaults will be used.');
       }
     </script>
     <div id="app" class="app"></div>

--- a/src/App.ui.spec.tsx
+++ b/src/App.ui.spec.tsx
@@ -13,7 +13,7 @@ test.describe('Basic application tests', () => {
   test('it has set the correct title', async ({
     page
   }) => {
-    await expect(page).toHaveTitle('Hello World');
+    await expect(page).toHaveTitle('SHOGun Client');
   });
 
   test('it renders the most important components', async ({

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,1 +1,10 @@
 declare module '*.png';
+
+declare module 'clientConfig' {
+  type ClientConfiguration = {
+    appPrefix?: string;
+  };
+  const config: ClientConfiguration;
+
+  export default config;
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,8 @@ import ConfigProvider from 'antd/lib/config-provider';
 import deDE from 'antd/lib/locale/de_DE';
 import enGB from 'antd/lib/locale/en_GB';
 
+import ClientConfiguration from 'clientConfig';
+
 import {
   defaults as OlControlDefaults
 } from 'ol/control';
@@ -50,8 +52,7 @@ import {
 import './index.less';
 
 const client = new SHOGunClient({
-  // TODO Make configurable
-  url: '/'
+  url: ClientConfiguration.appPrefix || '/'
 });
 
 const parser = new ShogunApplicationUtil({

--- a/src/store/title/index.ts
+++ b/src/store/title/index.ts
@@ -3,7 +3,7 @@ import {
   PayloadAction
 } from '@reduxjs/toolkit';
 
-const initialState: string = 'Default title';
+const initialState: string = 'SHOGun Client';
 
 export const slice = createSlice({
   name: 'title',

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -6,6 +6,9 @@ const customCssTheme = require('./antd.theme');
 
 module.exports = {
   entry: './src/index.tsx',
+  externals: {
+    clientConfig: 'clientConfig'
+  },
   module: {
     rules: [{
       test: /\.tsx?$/,

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -53,7 +53,7 @@ module.exports = {
   plugins: [
     new HtmlWebpackPlugin({
       filename: 'index.html',
-      title: 'Hello World',
+      title: 'SHOGun Client',
       template: path.join(__dirname, 'resources', 'public', 'index.ejs'),
       hash: true,
       minify: {


### PR DESCRIPTION
This introduces a configuration file for the client that can be used to set global options (currently the `appPrefix` is available only).

Please review @KaiVolland.