### PR TITLE
Open print in new browser tab

### DIFF
--- a/src/components/PrintForm/index.tsx
+++ b/src/components/PrintForm/index.tsx
@@ -102,7 +102,7 @@ export const PrintForm: React.FC<PrintFormProps> = ({
         throw new Error('No download URL available, the job has failed.');
       }
 
-      printManager.download(downloadUrl);
+      window.open(downloadUrl);
     } catch (error: any) {
       setErrorMsg(t('PrintForm.printJobErrorMsg'));
       Logger.error(error);


### PR DESCRIPTION
This MR suggests to use `window.open` instead of `printManager.download` which sets `window.locatio.href`.