### PR TITLE
GeoServerUtil and optional GeoServer login

### DIFF
--- a/resources/public/index.ejs
+++ b/resources/public/index.ejs
@@ -81,7 +81,7 @@
     <noscript>
       You need to enable JavaScript to run this app.
     </noscript>
-    <script src="/config/clientConfig.js"></script>
+    <script src="/gis-client-config.js"></script>
     <script>
       if (!window.clientConfig) {
         console.warn('No config found, client defaults will be used.');

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -3,6 +3,7 @@ declare module '*.png';
 declare module 'clientConfig' {
   type ClientConfiguration = {
     appPrefix?: string;
+    loginToGeoServer?: boolean;
   };
   const config: ClientConfiguration;
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -53,6 +53,7 @@ import {
 } from './store/title';
 
 import './index.less';
+import GeoServerUtil from './util/GeoServerUtil';
 
 // TODO: extend antd properties too
 export interface ThemeProperties extends React.CSSProperties {
@@ -226,6 +227,10 @@ const parseTheme = (theme?: any): ThemeProperties => {
 const renderApp = async () => {
   try {
     const appConfig = await getApplicationConfiguration();
+
+    if (ClientConfiguration.loginToGeoServer) {
+      await GeoServerUtil.getGeoServerSession();
+    }
 
     // @ts-ignore
     const style = parseTheme(appConfig?.clientConfig?.theme);

--- a/src/util/GeoServerUtil.ts
+++ b/src/util/GeoServerUtil.ts
@@ -1,21 +1,3 @@
-/*
- * Copyright (c) 2021-present terrestris GmbH & Co. KG.
- *
- * This file is part of IHK Webatlas.
- * See https://geoinfo.ihk.de for further info.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 export class GeoServerUtil {
 
   static async logout(): Promise<boolean> {

--- a/src/util/GeoServerUtil.ts
+++ b/src/util/GeoServerUtil.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2021-present terrestris GmbH & Co. KG.
+ *
+ * This file is part of IHK Webatlas.
+ * See https://geoinfo.ihk.de for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export class GeoServerUtil {
+
+  static async logout(): Promise<boolean> {
+    try {
+      const response = await fetch('/geoserver/j_spring_security_logout', {
+        credentials: 'include',
+        mode: 'no-cors',
+        method: 'POST',
+        redirect: 'manual'
+      });
+
+      if (response.ok) {
+        return Promise.resolve(true);
+      } else {
+        throw new Error(`Error while logging out from GeoServer. Status: ${response.status}, ` +
+          `Message: ${response.statusText}`);
+      }
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  }
+
+  static async getGeoServerSession(timeDelay: number = 0): Promise<boolean> {
+    try {
+      const response = await fetch('/geoserver/www/getsession.json', {
+        credentials: 'include',
+        mode: 'no-cors'
+      });
+
+      // As we're in no-cors mode, no response status
+      // will be available, but we assume that for status
+      // code 0 the user isn't logged in and a redirect to
+      // the identity provider has happened. In this case we
+      // have to delay resolving the promise (with a hacky
+      // timeout, if given :-/).
+      if (response.status <= 0) {
+        const delay = () => new Promise(res => setTimeout(res, timeDelay));
+
+        await delay();
+
+        return Promise.resolve(true);
+      } else if (response.ok) {
+        // If the status is ok, we're already logged in
+        // and we can resolve directly.
+        return Promise.resolve(true);
+      } else {
+        // Reject if something wrong happened.
+        throw new Error('Error while getting a GeoServer session');
+      }
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  }
+}
+
+export default GeoServerUtil;


### PR DESCRIPTION
This introduces the `GeoServerUtil` and adds an clientConfig option (`loginToGeoServer`) to log into the geoserver automatically.

:exclamation: This also changes the path of the client-config to be aligned with the admin-client-config.js