### PR TITLE
feat: make keycloak `onLoad` action configurable

### DIFF
--- a/resources/config/gis-client-config.js
+++ b/resources/config/gis-client-config.js
@@ -4,6 +4,7 @@ var clientConfig = {
     enabled: false,
     host: null,
     realm: null,
-    clientId: null
+    clientId: null,
+    onLoadAction: 'check-sso'
   }
 };

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -12,6 +12,7 @@ declare module 'clientConfig' {
       host?: string;
       realm?: string;
       clientId?: string;
+      onLoadAction?: KeycloakOnLoad;
     };
   };
   const config: ClientConfiguration;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -193,6 +193,7 @@ const setUserToStore = async (user?: User) => {
 
 const initKeycloak = async () => {
   const keycloakEnabled = ClientConfiguration.keycloak?.enabled;
+  const keycloakOnLoad = ClientConfiguration.keycloak?.onLoadAction;
   const keycloakHost = ClientConfiguration.keycloak?.host || KEYCLOAK_HOST;
   const keycloakRealm = ClientConfiguration.keycloak?.realm || KEYCLOAK_REALM;
   const keycloakClientId = ClientConfiguration.keycloak?.clientId || KEYCLOAK_CLIENT_ID;
@@ -228,7 +229,7 @@ const initKeycloak = async () => {
   };
 
   await keycloak.init({
-    onLoad: 'check-sso'
+    onLoad: keycloakOnLoad
   });
 
   return keycloak;


### PR DESCRIPTION
This makes the keycloak `onLoad` behavior configurable via `gis-client-config.js`:

- `check-sso` allows anonymous access without login
- `login-required` always redirects to keycloak login

For more details see the keycloak documentation: https://www.keycloak.org/docs/latest/securing_apps/#_javascript_adapter

Co-authored-by: Daniel Koch <koch@terrestris.de>

@terrestris/devs Please review