### PR TITLE
refactor: Toolbar-Styling

### DIFF
--- a/src/components/ToolMenu/Draw/index.less
+++ b/src/components/ToolMenu/Draw/index.less
@@ -6,5 +6,10 @@
     border: none;
     text-align: left;
     padding-left: 2rem;
+
+  }
+
+  .ant-btn > span {
+    margin-left: 10px;
   }
 }

--- a/src/components/ToolMenu/Draw/index.less
+++ b/src/components/ToolMenu/Draw/index.less
@@ -6,7 +6,6 @@
     border: none;
     text-align: left;
     padding-left: 2rem;
-
   }
 
   .ant-btn > span {

--- a/src/components/ToolMenu/Measure/index.less
+++ b/src/components/ToolMenu/Measure/index.less
@@ -5,4 +5,8 @@
     text-align: left;
     padding-left: 2rem;
   }
+
+  .ant-btn > span {
+    margin-left: 10px;
+  }
 }


### PR DESCRIPTION
Increases distance between svg and string of the Toolbar-Children.
![Auswahl_004](https://user-images.githubusercontent.com/100765498/180025694-3deb2616-33d9-4d8e-a8d7-dd82a776935d.png)
 