### PR TITLE
Harmonize button styles in measure and draw menu

### DIFF
--- a/src/components/ToolMenu/Draw/index.less
+++ b/src/components/ToolMenu/Draw/index.less
@@ -1,11 +1,16 @@
-.tool-menu .ant-menu .draw {
-
+.tool-menu .ant-menu .draw,
+.ant-menu-submenu-popup.draw {
   button {
-    width: 100%;
     border-radius: 0;
     border: none;
     text-align: left;
     padding-left: 2rem;
+
+    &.btn-pressed {
+      background-color: white;
+      color: var(--ant-primary-10);
+      font-weight: 500;
+    }
   }
 
   .ant-btn > span {

--- a/src/components/ToolMenu/Draw/index.tsx
+++ b/src/components/ToolMenu/Draw/index.tsx
@@ -83,6 +83,19 @@ export const Draw: React.FC<DrawProps> = (): JSX.Element => {
     }
   };
 
+  const onUploadChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const uploadedFiles = e.target.files;
+    if (
+      (uploadedFiles && uploadedFiles.length === 1) &&
+      (
+        uploadedFiles[0].type === 'application/geo+json' ||
+        uploadedFiles[0].type === 'application/geojson'
+      )
+    ) {
+      onGeoJSONUpload(uploadedFiles[0]);
+    }
+  };
+
   const onGeoJSONUpload = (geoJSONFile: File) => {
     const fileReader = new FileReader();
 
@@ -98,7 +111,6 @@ export const Draw: React.FC<DrawProps> = (): JSX.Element => {
         const digitizeLayerSource = digitizeLayer.getSource();
         digitizeLayerSource?.addFeatures(geoJSONFeatures);
       }
-
     };
 
     fileReader.readAsText(geoJSONFile);
@@ -113,88 +125,153 @@ export const Draw: React.FC<DrawProps> = (): JSX.Element => {
       <DrawButton
         name="drawPoint"
         drawType="Point"
+        type="link"
       >
-        <FontAwesomeIcon icon={faCircle} />
-        <span className="draw-point">{t('Draw.point')}</span>
+        <FontAwesomeIcon
+          icon={faCircle}
+        />
+        <span
+          className="draw-point"
+        >
+          {t('Draw.point')}
+        </span>
       </DrawButton>
 
       <DrawButton
         name="drawLine"
         drawType="LineString"
+        type="link"
       >
-        <FontAwesomeIcon icon={faGripLines} />
-        <span className="draw-line">{t('Draw.line')}</span>
+        <FontAwesomeIcon
+          icon={faGripLines}
+        />
+        <span
+          className="draw-line"
+        >
+          {t('Draw.line')}
+        </span>
       </DrawButton>
 
       <DrawButton
         name="drawPolygon"
         drawType="Polygon"
+        type="link"
       >
-        <FontAwesomeIcon icon={faDrawPolygon} />
-        <span className="draw-polygon">{t('Draw.polygon')}</span>
+        <FontAwesomeIcon
+          icon={faDrawPolygon}
+        />
+        <span
+          className="draw-polygon"
+        >
+          {t('Draw.polygon')}
+        </span>
       </DrawButton>
 
       <DrawButton
         name="drawCircle"
         drawType="Circle"
+        type="link"
       >
-        <FontAwesomeIcon icon={faCircle} />
-        <span className="draw-circle">{t('Draw.circle')}</span>
+        <FontAwesomeIcon
+          icon={faCircle}
+        />
+        <span
+          className="draw-circle"
+        >
+          {t('Draw.circle')}
+        </span>
       </DrawButton>
 
       <DrawButton
         name="drawRectangle"
         drawType="Rectangle"
+        type="link"
       >
-        <FontAwesomeIcon icon={faSquare} />
-        <span className="draw-rectangle">{t('Draw.rectangle')}</span>
+        <FontAwesomeIcon
+          icon={faSquare}
+        />
+        <span
+          className="draw-rectangle"
+        >
+          {t('Draw.rectangle')}
+        </span>
       </DrawButton>
 
       <DrawButton
         name="drawText"
         drawType="Text"
+        type="link"
       >
-        <FontAwesomeIcon icon={faFont} />
-        <span className="draw-text">{t('Draw.text')}</span>
+        <FontAwesomeIcon
+          icon={faFont}
+        />
+        <span
+          className="draw-text"
+        >
+          {t('Draw.text')}
+        </span>
       </DrawButton>
 
-      <ModifyButton name='draw-modify'>
-        <FontAwesomeIcon icon={faPenToSquare} />
-        <span className="draw-modify">{t('Draw.modify')}</span>
+      <ModifyButton
+        name="draw-modify"
+        type="link"
+      >
+        <FontAwesomeIcon
+          icon={faPenToSquare}
+        />
+        <span
+          className="draw-modify"
+        >
+          {t('Draw.modify')}
+        </span>
       </ModifyButton>
 
       <UploadButton
-        name='draw-upload'
-        onChange={(e: ChangeEvent<HTMLInputElement>) => {
-          const uploadedFiles = e.target.files;
-          if (
-            (uploadedFiles && uploadedFiles.length === 1) &&
-            (
-              uploadedFiles[0].type === 'application/geo+json' ||
-              uploadedFiles[0].type === 'application/geojson'
-            )
-          ) {
-            onGeoJSONUpload(uploadedFiles[0]);
-          }
-        }}
+        name="draw-upload"
+        onChange={onUploadChange}
+        type="link"
       >
-        <SimpleButton>
-          <FontAwesomeIcon icon={faUpload} />
-          <span className="draw-upload">{t('Draw.upload')}</span>
+        <SimpleButton
+          type="link"
+        >
+          <FontAwesomeIcon
+            icon={faUpload}
+          />
+          <span
+            className="draw-upload"
+          >
+            {t('Draw.upload')}
+          </span>
         </SimpleButton>
       </UploadButton>
 
       <SimpleButton
-        name='draw-export'
+        name="draw-export"
         onClick={onGeoJSONDownload}
+        type="link"
       >
-        <FontAwesomeIcon icon={faDownload} />
-        <span className="draw-export">{t('Draw.export')}</span>
+        <FontAwesomeIcon
+          icon={faDownload}
+        />
+        <span
+          className="draw-export"
+        >
+          {t('Draw.export')}
+        </span>
       </SimpleButton>
 
-      <DeleteButton name='draw-delete'>
-        <FontAwesomeIcon icon={faTrash} />
-        <span className="draw-delete">{t('Draw.delete')}</span>
+      <DeleteButton
+        name="draw-delete"
+        type="link"
+      >
+        <FontAwesomeIcon
+          icon={faTrash}
+        />
+        <span
+          className="draw-delete"
+        >
+          {t('Draw.delete')}
+        </span>
       </DeleteButton>
 
     </ToggleGroup>

--- a/src/components/ToolMenu/Measure/index.less
+++ b/src/components/ToolMenu/Measure/index.less
@@ -1,9 +1,16 @@
-.tool-menu .ant-menu .measure {
+.tool-menu .ant-menu .measure,
+.ant-menu-submenu-popup.measure {
   button {
     border-radius: 0;
     border: none;
     text-align: left;
     padding-left: 2rem;
+
+    &.btn-pressed {
+      background-color: white;
+      color: var(--ant-primary-10);
+      font-weight: 500;
+    }
   }
 
   .ant-btn > span {

--- a/src/components/ToolMenu/index.less
+++ b/src/components/ToolMenu/index.less
@@ -10,7 +10,6 @@
   max-width: 600px;
 
   .ant-menu {
-
     &.ant-menu-inline-collapsed {
       width: 40px;
     }
@@ -46,7 +45,6 @@
 
       &.ant-menu-item-selected,
       &.ant-menu-submenu-open {
-
         >.ant-menu-submenu-title {
           font-weight: bolder;
         }
@@ -54,7 +52,6 @@
         &::after {
           display: none;
         }
-
       }
     }
 
@@ -76,8 +73,8 @@
 .ant-menu-submenu-popup {
   button,
   button.react-geo-togglebutton {
-    border: none !important;
     border-radius: 0;
+    border: none;
   }
 
   .tree-wrapper {

--- a/src/components/ToolMenu/index.tsx
+++ b/src/components/ToolMenu/index.tsx
@@ -101,8 +101,6 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
   } = useTranslation();
   const map = useMap();
 
-  const client = useSHOGunAPIClient();
-
   const dispatch = useAppDispatch();
   const selectedKeys = useAppSelector(state => state.toolMenu.selectedKeys);
 
@@ -199,7 +197,7 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
 
   const onOpenChange = (openKeys: string[]) => {
     if (collapsed) {
-      openKeys = openKeys.filter(k => k === 'measure_tools' || k === 'expand_collapse');
+      openKeys = openKeys.filter(k => k === 'measure_tools' || k === 'draw_tools' || k === 'expand_collapse');
     }
     setActiveSubmenuKeys(openKeys);
   };
@@ -214,6 +212,7 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
     {
       className: 'measure',
       key: 'measure_tools',
+      popupClassName: 'measure',
       icon: <FontAwesomeIcon icon={faRuler} />,
       label: t('ToolMenu.measure'),
       children: [
@@ -226,6 +225,7 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
     {
       className: 'draw',
       key: 'draw_tools',
+      popupClassName: 'draw',
       icon: <FontAwesomeIcon icon={faDrawPolygon} />,
       label: t('ToolMenu.draw'),
       children: [


### PR DESCRIPTION
This harmonizes the button styles in the measure and draw menu.

![image](https://user-images.githubusercontent.com/1137620/180146278-2d536300-2de0-4798-bfaa-8acb8dadcbd6.png)

It also applies the style to the submenu that will be used for the collapsed tool menu.

![image](https://user-images.githubusercontent.com/1137620/180146493-fe37affa-5662-4d24-a490-c1d7f0a51027.png)

Please review @terrestris/devs.