### PR TITLE
Fix print for internal layers

### DIFF
--- a/src/components/ToolMenu/index.tsx
+++ b/src/components/ToolMenu/index.tsx
@@ -102,6 +102,7 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
     t
   } = useTranslation();
   const map = useMap();
+  const client = useSHOGunAPIClient();
 
   const dispatch = useAppDispatch();
   const selectedKeys = useAppSelector(state => state.toolMenu.selectedKeys);
@@ -151,7 +152,7 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
       timeout: 60000,
       layerFilter,
       headers: {
-        ...getBearerTokenHeader()
+        ...getBearerTokenHeader(client?.getKeycloak())
       },
       transformOpts: {
         rotate: false


### PR DESCRIPTION
This fixes the print for internal layers by passing the keycloak client (if present) to the bearer token header generator.

Please review @terrestris/devs.