### PR TITLE
Fix console warnings about component usage

### DIFF
--- a/src/components/ToolMenu/index.tsx
+++ b/src/components/ToolMenu/index.tsx
@@ -26,6 +26,9 @@ import {
   Menu,
   MenuProps
 } from 'antd';
+import {
+  ItemType
+} from 'antd/lib/menu/hooks/useItems';
 
 import OlLayerGroup from 'ol/layer/Group';
 import OlLayer from 'ol/layer/Layer';
@@ -212,7 +215,7 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
     setActiveSubmenuKeys([key.key]);
   };
 
-  const items=[];
+  const items = [];
 
   if (availableTools.includes('default') || availableTools.includes('measure_tools')) {
     items.push({
@@ -354,7 +357,7 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
     items.push(
       {
         type: 'divider'
-      },
+      } as ItemType,
       {
         key: 'language_selector',
         onTitleClick: onSubmenuTitleClick,

--- a/src/components/ToolMenu/index.tsx
+++ b/src/components/ToolMenu/index.tsx
@@ -353,8 +353,7 @@ export const ToolMenu: React.FC<ToolMenuProps> = ({
   if (availableTools.includes('default') || availableTools.includes('language_selector')) {
     items.push(
       {
-        key: 'divider',
-        label: <Menu.Divider />
+        type: 'divider'
       },
       {
         key: 'language_selector',

--- a/src/components/UserMenu/index.tsx
+++ b/src/components/UserMenu/index.tsx
@@ -81,7 +81,7 @@ export const UserMenu: React.FC<UserProps> = (): JSX.Element => {
   };
 
   const getMenu = () => {
-    const login = {
+    const login: ItemType = {
       key: 'login',
       icon: (
         <FontAwesomeIcon
@@ -91,7 +91,7 @@ export const UserMenu: React.FC<UserProps> = (): JSX.Element => {
       label: t('UserMenu.loginMenuTitle')
     };
 
-    const username = {
+    const username: ItemType = {
       key: 'username',
       label: (
         <div
@@ -106,11 +106,11 @@ export const UserMenu: React.FC<UserProps> = (): JSX.Element => {
       )
     };
 
-    const divider = {
+    const divider: ItemType = {
       type: 'divider'
     };
 
-    const settings = {
+    const settings: ItemType = {
       key: 'settings',
       icon: (
         <FontAwesomeIcon
@@ -120,7 +120,7 @@ export const UserMenu: React.FC<UserProps> = (): JSX.Element => {
       label: t('UserMenu.settingsMenuTitle')
     };
 
-    const info = {
+    const info: ItemType = {
       key: 'info',
       icon: (
         <FontAwesomeIcon
@@ -140,7 +140,7 @@ export const UserMenu: React.FC<UserProps> = (): JSX.Element => {
       )
     };
 
-    const logout = {
+    const logout: ItemType = {
       key: 'logout',
       icon: (
         <FontAwesomeIcon

--- a/src/components/UserMenu/index.tsx
+++ b/src/components/UserMenu/index.tsx
@@ -107,7 +107,6 @@ export const UserMenu: React.FC<UserProps> = (): JSX.Element => {
     };
 
     const divider = {
-      key: 'divider',
       type: 'divider'
     };
 


### PR DESCRIPTION
This fixes two console warnings by:

- fixing a potential duplicated usage of a key.
- replacing the direct usage of `<Menu.Divider />` with ` type: 'divider'`.

Please review @terrestris/devs.