### PR TITLE
fix: assigns the correct name to identify the layer

### DIFF
--- a/src/components/ToolMenu/LayerTree/LayerTreeContextMenu/index.tsx
+++ b/src/components/ToolMenu/LayerTree/LayerTreeContextMenu/index.tsx
@@ -123,7 +123,7 @@ export const LayerTreeContextMenu: React.FC<LayerTreeContextMenuProps> = ({
       return;
     }
 
-    const targetFolderName = t('LayerTree.externalWmsFolder');
+    const targetFolderName = t('AddLayerModal.externalWmsFolder');
     const targetGroup: LayerGroup = MapUtil.getLayerByName(map, targetFolderName) as LayerGroup;
     if (targetGroup) {
       const existingLayers = targetGroup.getLayers();

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -49,7 +49,6 @@ export default {
       },
       LayerTree: {
         transparency: 'Transparenz',
-        externalWmsFolder: 'Externe Dienste',
         noLegendAvailable: 'Keine Legende verfügbar'
       },
       LayerTreeContextMenu: {
@@ -162,7 +161,6 @@ export default {
       },
       LayerTree: {
         transparency: 'Transparency',
-        externalWmsFolder: 'External services',
         noLegendAvailable: 'No legend available'
       },
       LayerTreeContextMenu: {


### PR DESCRIPTION
The WMS-layers could not be removed because the variable targetFolderName was assigned to a wrong name, so targetGroup was undefined.
Thus the unneeded key value pair externalWmsFolder: 'External services' was deleted.