### PR TITLE
Rename to `@terrestris/shogun-gis-client`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           context: .
           tags: |
-            ${{ env.DOCKER_REGISTRY }}/shogun-demo-client:latest
+            ${{ env.DOCKER_REGISTRY }}/shogun-gis-client:latest
           load: true
 
       - name: Build docker image (version)
@@ -49,14 +49,14 @@ jobs:
         with:
           context: .
           tags: |
-            ${{ env.DOCKER_REGISTRY }}/shogun-demo-client:${{ steps.semantic.outputs.new_release_version }}
+            ${{ env.DOCKER_REGISTRY }}/shogun-gis-client:${{ steps.semantic.outputs.new_release_version }}
           load: true
 
       - name: Push docker image to Nexus (latest)
         run: |
-          docker push ${{ env.DOCKER_REGISTRY }}/shogun-demo-client:latest
+          docker push ${{ env.DOCKER_REGISTRY }}/shogun-gis-client:latest
 
       - name: Push docker image to Nexus (version)
         if: steps.semantic.outputs.new_release_published == 'true'
         run: |
-          docker push ${{ env.DOCKER_REGISTRY }}/shogun-demo-client:${{ steps.semantic.outputs.new_release_version }}
+          docker push ${{ env.DOCKER_REGISTRY }}/shogun-gis-client:${{ steps.semantic.outputs.new_release_version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,409 +1,409 @@
-## [3.4.1](https://github.com/terrestris/shogun-demo-client/compare/v3.4.0...v3.4.1) (2022-08-10)
+## [3.4.1](https://github.com/terrestris/shogun-gis-client/compare/v3.4.0...v3.4.1) (2022-08-10)
 
 
 ### Changes in configuration
 
-* scans the jest coverage and sends a report to sonarqube ([#239](https://github.com/terrestris/shogun-demo-client/issues/239)) ([3159cc7](https://github.com/terrestris/shogun-demo-client/commit/3159cc7ce470d67c0d194e2e8c23da63fd86006c))
+* scans the jest coverage and sends a report to sonarqube ([#239](https://github.com/terrestris/shogun-gis-client/issues/239)) ([3159cc7](https://github.com/terrestris/shogun-gis-client/commit/3159cc7ce470d67c0d194e2e8c23da63fd86006c))
 
 
 ### Dependencies
 
-* **deps-dev:** bump @testing-library/jest-dom from 5.16.4 to 5.16.5 ([c26f1af](https://github.com/terrestris/shogun-demo-client/commit/c26f1afc620259d68ae4c6c15255353dedf81116))
-* **deps-dev:** bump @typescript-eslint/eslint-plugin ([84f9fe2](https://github.com/terrestris/shogun-demo-client/commit/84f9fe2b404b95d0b054246d4be92e97ca0a3035))
-* **deps-dev:** bump @typescript-eslint/parser from 5.32.0 to 5.33.0 ([19b78d3](https://github.com/terrestris/shogun-demo-client/commit/19b78d364ec09301d7def229a9e175cff8aa42e3))
-* **deps:** bump antd from 4.22.3 to 4.22.4 ([14abf62](https://github.com/terrestris/shogun-demo-client/commit/14abf620d7c3469e395e71002a694469b27815df))
-* **deps:** bump i18next from 21.8.16 to 21.9.0 ([55ca251](https://github.com/terrestris/shogun-demo-client/commit/55ca251df22678bdbbf59f287b716880e180534c))
+* **deps-dev:** bump @testing-library/jest-dom from 5.16.4 to 5.16.5 ([c26f1af](https://github.com/terrestris/shogun-gis-client/commit/c26f1afc620259d68ae4c6c15255353dedf81116))
+* **deps-dev:** bump @typescript-eslint/eslint-plugin ([84f9fe2](https://github.com/terrestris/shogun-gis-client/commit/84f9fe2b404b95d0b054246d4be92e97ca0a3035))
+* **deps-dev:** bump @typescript-eslint/parser from 5.32.0 to 5.33.0 ([19b78d3](https://github.com/terrestris/shogun-gis-client/commit/19b78d364ec09301d7def229a9e175cff8aa42e3))
+* **deps:** bump antd from 4.22.3 to 4.22.4 ([14abf62](https://github.com/terrestris/shogun-gis-client/commit/14abf620d7c3469e395e71002a694469b27815df))
+* **deps:** bump i18next from 21.8.16 to 21.9.0 ([55ca251](https://github.com/terrestris/shogun-gis-client/commit/55ca251df22678bdbbf59f287b716880e180534c))
 
 
 ### Bugfixes
 
-* adjusts the [@media](https://github.com/media) query ([bbadcf9](https://github.com/terrestris/shogun-demo-client/commit/bbadcf94a216d9ab942b9a8ebc409b1b7c272c4f))
-* assigns the correct name to identify the layer ([8cd702b](https://github.com/terrestris/shogun-demo-client/commit/8cd702baabf8a0864b9f4520bc767583844e34e2))
+* adjusts the [@media](https://github.com/media) query ([bbadcf9](https://github.com/terrestris/shogun-gis-client/commit/bbadcf94a216d9ab942b9a8ebc409b1b7c272c4f))
+* assigns the correct name to identify the layer ([8cd702b](https://github.com/terrestris/shogun-gis-client/commit/8cd702baabf8a0864b9f4520bc767583844e34e2))
 
-## [3.4.0](https://github.com/terrestris/shogun-demo-client/compare/v3.3.0...v3.4.0) (2022-08-02)
+## [3.4.0](https://github.com/terrestris/shogun-gis-client/compare/v3.3.0...v3.4.0) (2022-08-02)
 
 
 ### Features
 
-* **toolconfig:** added possibility to control tools that are shown through client config ([2f1a87e](https://github.com/terrestris/shogun-demo-client/commit/2f1a87ef05ea45ceaed53d55165566b5e5465495))
+* **toolconfig:** added possibility to control tools that are shown through client config ([2f1a87e](https://github.com/terrestris/shogun-gis-client/commit/2f1a87ef05ea45ceaed53d55165566b5e5465495))
 
 
 ### Dependencies
 
-* conflicts resolved ([1e595d6](https://github.com/terrestris/shogun-demo-client/commit/1e595d625142fbdbafc962eea365efbcd65553fa))
-* **deps-dev:** bump @babel/core from 7.18.9 to 7.18.10 ([100ea3e](https://github.com/terrestris/shogun-demo-client/commit/100ea3e35e30e9bbc3dbd0078dd332cddfa01618))
-* **deps-dev:** bump @babel/preset-env from 7.18.9 to 7.18.10 ([7295958](https://github.com/terrestris/shogun-demo-client/commit/7295958cb7fee9141a41432ddfbdad0066a4e271))
-* **deps-dev:** bump @playwright/test from 1.24.1 to 1.24.2 ([3ba31a3](https://github.com/terrestris/shogun-demo-client/commit/3ba31a30ab50786356bfb293243bff078834a248))
-* **deps-dev:** bump @typescript-eslint/eslint-plugin ([15f6fe1](https://github.com/terrestris/shogun-demo-client/commit/15f6fe11a5b2823c3d29097dc4b67be38faeca2a))
-* **deps-dev:** bump @typescript-eslint/parser from 5.31.0 to 5.32.0 ([f7ec393](https://github.com/terrestris/shogun-demo-client/commit/f7ec393bc1564354d85b5b0a601ce0ce3a0af9dc))
-* **deps-dev:** bump eslint from 8.20.0 to 8.21.0 ([eb7d209](https://github.com/terrestris/shogun-demo-client/commit/eb7d209c13785f4dbb0b010ac143c3b949942f7c))
-* **deps:** bump @terrestris/shogun-util from 3.2.0 to 3.2.2 ([b6250d1](https://github.com/terrestris/shogun-demo-client/commit/b6250d140b8bc81e36bc91cc02c1ab9ff1d39829))
-* **deps:** bump antd from 4.22.1 to 4.22.2 ([60f7fde](https://github.com/terrestris/shogun-demo-client/commit/60f7fde003c16d5fa54808093d3132fca36ae92d))
-* **deps:** bump antd from 4.22.2 to 4.22.3 ([c87c217](https://github.com/terrestris/shogun-demo-client/commit/c87c217a9ab9a1fda68e1bc640d7796ae6e2f1b1))
-* **deps:** bump i18next from 21.8.14 to 21.8.16 ([38c7c2e](https://github.com/terrestris/shogun-demo-client/commit/38c7c2e28a4960399921c192803ca04d14cc13f4))
-* **deps:** bump keycloak-js from 18.0.1 to 19.0.0 ([fb16dbd](https://github.com/terrestris/shogun-demo-client/commit/fb16dbd03b2e6ad999e429782fa53192ac3688fa))
-* **deps:** bump keycloak-js from 19.0.0 to 19.0.1 ([907e82d](https://github.com/terrestris/shogun-demo-client/commit/907e82d9b74afb0095aa9adecde25a205db6ce92))
-* **draw-and-modify:** fixed types issues ([bd4e708](https://github.com/terrestris/shogun-demo-client/commit/bd4e708853632460881de9e2f3ff1727af853d0b))
-* **tool-filter:** added separate store for available tools ([0a0d772](https://github.com/terrestris/shogun-demo-client/commit/0a0d772a5f446f5fdff40425a4c49a8977ed5a12))
-* **tool-filter:** conflicts resolved ([36ddf6d](https://github.com/terrestris/shogun-demo-client/commit/36ddf6dc4e9c34321454f219be706db2a7881977))
-* **tool-filtering:** fixed bug due to previous type linting. Added default fallback ([e90a23c](https://github.com/terrestris/shogun-demo-client/commit/e90a23ca9bd8652008a281d6b05e91fc451dcce6))
-* **tools:** cleaned clientconfig. Changes to get the tools config from the store ([b6d2456](https://github.com/terrestris/shogun-demo-client/commit/b6d2456aa576bfaaee3e56de7635adffbdfa7822))
-* update ol-util ([7c8fd20](https://github.com/terrestris/shogun-demo-client/commit/7c8fd20a1f2d77f28c1f212e9243111328f7084a))
-* update ol, react-geo and shogun-util ([faef47a](https://github.com/terrestris/shogun-demo-client/commit/faef47a6c6880f51b86ed05ae603d751d39f1c6b))
-* update react-geo ([28c99f5](https://github.com/terrestris/shogun-demo-client/commit/28c99f5be87628c43dd7da727bb8d78d26bf30f2))
+* conflicts resolved ([1e595d6](https://github.com/terrestris/shogun-gis-client/commit/1e595d625142fbdbafc962eea365efbcd65553fa))
+* **deps-dev:** bump @babel/core from 7.18.9 to 7.18.10 ([100ea3e](https://github.com/terrestris/shogun-gis-client/commit/100ea3e35e30e9bbc3dbd0078dd332cddfa01618))
+* **deps-dev:** bump @babel/preset-env from 7.18.9 to 7.18.10 ([7295958](https://github.com/terrestris/shogun-gis-client/commit/7295958cb7fee9141a41432ddfbdad0066a4e271))
+* **deps-dev:** bump @playwright/test from 1.24.1 to 1.24.2 ([3ba31a3](https://github.com/terrestris/shogun-gis-client/commit/3ba31a30ab50786356bfb293243bff078834a248))
+* **deps-dev:** bump @typescript-eslint/eslint-plugin ([15f6fe1](https://github.com/terrestris/shogun-gis-client/commit/15f6fe11a5b2823c3d29097dc4b67be38faeca2a))
+* **deps-dev:** bump @typescript-eslint/parser from 5.31.0 to 5.32.0 ([f7ec393](https://github.com/terrestris/shogun-gis-client/commit/f7ec393bc1564354d85b5b0a601ce0ce3a0af9dc))
+* **deps-dev:** bump eslint from 8.20.0 to 8.21.0 ([eb7d209](https://github.com/terrestris/shogun-gis-client/commit/eb7d209c13785f4dbb0b010ac143c3b949942f7c))
+* **deps:** bump @terrestris/shogun-util from 3.2.0 to 3.2.2 ([b6250d1](https://github.com/terrestris/shogun-gis-client/commit/b6250d140b8bc81e36bc91cc02c1ab9ff1d39829))
+* **deps:** bump antd from 4.22.1 to 4.22.2 ([60f7fde](https://github.com/terrestris/shogun-gis-client/commit/60f7fde003c16d5fa54808093d3132fca36ae92d))
+* **deps:** bump antd from 4.22.2 to 4.22.3 ([c87c217](https://github.com/terrestris/shogun-gis-client/commit/c87c217a9ab9a1fda68e1bc640d7796ae6e2f1b1))
+* **deps:** bump i18next from 21.8.14 to 21.8.16 ([38c7c2e](https://github.com/terrestris/shogun-gis-client/commit/38c7c2e28a4960399921c192803ca04d14cc13f4))
+* **deps:** bump keycloak-js from 18.0.1 to 19.0.0 ([fb16dbd](https://github.com/terrestris/shogun-gis-client/commit/fb16dbd03b2e6ad999e429782fa53192ac3688fa))
+* **deps:** bump keycloak-js from 19.0.0 to 19.0.1 ([907e82d](https://github.com/terrestris/shogun-gis-client/commit/907e82d9b74afb0095aa9adecde25a205db6ce92))
+* **draw-and-modify:** fixed types issues ([bd4e708](https://github.com/terrestris/shogun-gis-client/commit/bd4e708853632460881de9e2f3ff1727af853d0b))
+* **tool-filter:** added separate store for available tools ([0a0d772](https://github.com/terrestris/shogun-gis-client/commit/0a0d772a5f446f5fdff40425a4c49a8977ed5a12))
+* **tool-filter:** conflicts resolved ([36ddf6d](https://github.com/terrestris/shogun-gis-client/commit/36ddf6dc4e9c34321454f219be706db2a7881977))
+* **tool-filtering:** fixed bug due to previous type linting. Added default fallback ([e90a23c](https://github.com/terrestris/shogun-gis-client/commit/e90a23ca9bd8652008a281d6b05e91fc451dcce6))
+* **tools:** cleaned clientconfig. Changes to get the tools config from the store ([b6d2456](https://github.com/terrestris/shogun-gis-client/commit/b6d2456aa576bfaaee3e56de7635adffbdfa7822))
+* update ol-util ([7c8fd20](https://github.com/terrestris/shogun-gis-client/commit/7c8fd20a1f2d77f28c1f212e9243111328f7084a))
+* update ol, react-geo and shogun-util ([faef47a](https://github.com/terrestris/shogun-gis-client/commit/faef47a6c6880f51b86ed05ae603d751d39f1c6b))
+* update react-geo ([28c99f5](https://github.com/terrestris/shogun-gis-client/commit/28c99f5be87628c43dd7da727bb8d78d26bf30f2))
 
 
 ### Bugfixes
 
-* activate semantic-release/github plugin ([a0a4ed1](https://github.com/terrestris/shogun-demo-client/commit/a0a4ed1b3c938bd49bfea92ef7e4d21a81da8bd3))
-* apply bearer token for GFI if needed ([9819b6b](https://github.com/terrestris/shogun-demo-client/commit/9819b6b23d07749955ba8b5cdb5b6f364ccf225d))
-* pass the keycloak client to the bearer token header generator ([e05a29b](https://github.com/terrestris/shogun-demo-client/commit/e05a29b3e1affbb95198591226ff42df7ee5be5f))
-* set correct types ([9451c2e](https://github.com/terrestris/shogun-demo-client/commit/9451c2e7c452b6b6a6be7e02906aba70cae44f09))
-* take warning about duplicated key and correct menu divider into account ([5d3b37c](https://github.com/terrestris/shogun-demo-client/commit/5d3b37ca4ff407c0c7737d74793055abad8e907f))
+* activate semantic-release/github plugin ([a0a4ed1](https://github.com/terrestris/shogun-gis-client/commit/a0a4ed1b3c938bd49bfea92ef7e4d21a81da8bd3))
+* apply bearer token for GFI if needed ([9819b6b](https://github.com/terrestris/shogun-gis-client/commit/9819b6b23d07749955ba8b5cdb5b6f364ccf225d))
+* pass the keycloak client to the bearer token header generator ([e05a29b](https://github.com/terrestris/shogun-gis-client/commit/e05a29b3e1affbb95198591226ff42df7ee5be5f))
+* set correct types ([9451c2e](https://github.com/terrestris/shogun-gis-client/commit/9451c2e7c452b6b6a6be7e02906aba70cae44f09))
+* take warning about duplicated key and correct menu divider into account ([5d3b37c](https://github.com/terrestris/shogun-gis-client/commit/5d3b37ca4ff407c0c7737d74793055abad8e907f))
 
-## [3.3.0](https://github.com/terrestris/shogun-demo-client/compare/v3.2.0...v3.3.0) (2022-07-28)
+## [3.3.0](https://github.com/terrestris/shogun-gis-client/compare/v3.2.0...v3.3.0) (2022-07-28)
 
 
 ### Features
 
-* **draw-export:** added button to draw tools and method to export drawn features ([c09a2f5](https://github.com/terrestris/shogun-demo-client/commit/c09a2f537a390e0493dfdac8b176334d17c0f237))
-* **draw:** added draw component and translations ([f8b7a05](https://github.com/terrestris/shogun-demo-client/commit/f8b7a0536d0847772a17538ce738ad6edcd904e7))
-* **draw:** added edit, remove and delete buttons ([31e0a67](https://github.com/terrestris/shogun-demo-client/commit/31e0a67ad7476e5494962a53a8e921c6d5022b74))
-* implements the client version into the footer ([410564c](https://github.com/terrestris/shogun-demo-client/commit/410564c80ed9e4b15f279208fc5a6b1de6de2d54))
-* language selector ([#172](https://github.com/terrestris/shogun-demo-client/issues/172)) ([78418c1](https://github.com/terrestris/shogun-demo-client/commit/78418c113d6c8b3f89748a0d359c17a6f36436c3))
-* make keycloak onload action configurable ([83a8f66](https://github.com/terrestris/shogun-demo-client/commit/83a8f66359a66e7d5a5c09ffac04ba0e6fe6db3c))
-* save selection ([#176](https://github.com/terrestris/shogun-demo-client/issues/176)) ([d06b215](https://github.com/terrestris/shogun-demo-client/commit/d06b215f8c8235ca8f676cb69ecfc065c973386a))
+* **draw-export:** added button to draw tools and method to export drawn features ([c09a2f5](https://github.com/terrestris/shogun-gis-client/commit/c09a2f537a390e0493dfdac8b176334d17c0f237))
+* **draw:** added draw component and translations ([f8b7a05](https://github.com/terrestris/shogun-gis-client/commit/f8b7a0536d0847772a17538ce738ad6edcd904e7))
+* **draw:** added edit, remove and delete buttons ([31e0a67](https://github.com/terrestris/shogun-gis-client/commit/31e0a67ad7476e5494962a53a8e921c6d5022b74))
+* implements the client version into the footer ([410564c](https://github.com/terrestris/shogun-gis-client/commit/410564c80ed9e4b15f279208fc5a6b1de6de2d54))
+* language selector ([#172](https://github.com/terrestris/shogun-gis-client/issues/172)) ([78418c1](https://github.com/terrestris/shogun-gis-client/commit/78418c113d6c8b3f89748a0d359c17a6f36436c3))
+* make keycloak onload action configurable ([83a8f66](https://github.com/terrestris/shogun-gis-client/commit/83a8f66359a66e7d5a5c09ffac04ba0e6fe6db3c))
+* save selection ([#176](https://github.com/terrestris/shogun-gis-client/issues/176)) ([d06b215](https://github.com/terrestris/shogun-gis-client/commit/d06b215f8c8235ca8f676cb69ecfc065c973386a))
 
 
 ### Bugfixes
 
-* deletes empty line ([9f481d6](https://github.com/terrestris/shogun-demo-client/commit/9f481d654ef04c5035bb0a9a01e8459f4fd3fd46))
-* deletes unneccessary translation ([9166a47](https://github.com/terrestris/shogun-demo-client/commit/9166a478bb7f200761ddc64fa0db11a27df4b3a7))
-* lower z-index to prevent icon from overlap app elements ([b463610](https://github.com/terrestris/shogun-demo-client/commit/b4636102d8ae1b677141fdfb69d8aaf419951b8c))
-* make Header and Footer more responsive ([badde0e](https://github.com/terrestris/shogun-demo-client/commit/badde0ec442266c232b2a98b0531cbfe01818915))
-* remove the unneeded integration of the Permalink component in the main application ([57d961e](https://github.com/terrestris/shogun-demo-client/commit/57d961ec68b1aed17afb595f4479ba2c1d55f96a))
-* removes unwanted imports ([cd7e8c1](https://github.com/terrestris/shogun-demo-client/commit/cd7e8c1207e73481e78cd041cdcd8e09ce5f774a))
-* show the expand/collapse buttons in the tree ([aac41b7](https://github.com/terrestris/shogun-demo-client/commit/aac41b77924aba62dd7724a6e8b36748e832933c))
+* deletes empty line ([9f481d6](https://github.com/terrestris/shogun-gis-client/commit/9f481d654ef04c5035bb0a9a01e8459f4fd3fd46))
+* deletes unneccessary translation ([9166a47](https://github.com/terrestris/shogun-gis-client/commit/9166a478bb7f200761ddc64fa0db11a27df4b3a7))
+* lower z-index to prevent icon from overlap app elements ([b463610](https://github.com/terrestris/shogun-gis-client/commit/b4636102d8ae1b677141fdfb69d8aaf419951b8c))
+* make Header and Footer more responsive ([badde0e](https://github.com/terrestris/shogun-gis-client/commit/badde0ec442266c232b2a98b0531cbfe01818915))
+* remove the unneeded integration of the Permalink component in the main application ([57d961e](https://github.com/terrestris/shogun-gis-client/commit/57d961ec68b1aed17afb595f4479ba2c1d55f96a))
+* removes unwanted imports ([cd7e8c1](https://github.com/terrestris/shogun-gis-client/commit/cd7e8c1207e73481e78cd041cdcd8e09ce5f774a))
+* show the expand/collapse buttons in the tree ([aac41b7](https://github.com/terrestris/shogun-gis-client/commit/aac41b77924aba62dd7724a6e8b36748e832933c))
 
 
 ### Changes in layout
 
-* adjust pressed style and set style for collapsed submenu as well ([a0cb522](https://github.com/terrestris/shogun-demo-client/commit/a0cb5222b42ec0d7e215bcf4739e80ec8ee6ae16))
-* align items and add space between label and value ([b9592a7](https://github.com/terrestris/shogun-demo-client/commit/b9592a7b28de67527b8b3ab2edd3a3981d762677))
-* reformat and set type to link ([14def14](https://github.com/terrestris/shogun-demo-client/commit/14def14945dc191af1cc0be6362200e2b3bfeaf3))
-* Toolmenu styling ([#206](https://github.com/terrestris/shogun-demo-client/issues/206)) ([4fa4daa](https://github.com/terrestris/shogun-demo-client/commit/4fa4daabd5965d6fe334bc5caa67ca0d517672a2))
+* adjust pressed style and set style for collapsed submenu as well ([a0cb522](https://github.com/terrestris/shogun-gis-client/commit/a0cb5222b42ec0d7e215bcf4739e80ec8ee6ae16))
+* align items and add space between label and value ([b9592a7](https://github.com/terrestris/shogun-gis-client/commit/b9592a7b28de67527b8b3ab2edd3a3981d762677))
+* reformat and set type to link ([14def14](https://github.com/terrestris/shogun-gis-client/commit/14def14945dc191af1cc0be6362200e2b3bfeaf3))
+* Toolmenu styling ([#206](https://github.com/terrestris/shogun-gis-client/issues/206)) ([4fa4daa](https://github.com/terrestris/shogun-gis-client/commit/4fa4daabd5965d6fe334bc5caa67ca0d517672a2))
 
 
 ### Dependencies
 
-* **deps-dev:** bump @babel/core from 7.18.6 to 7.18.9 ([0523b77](https://github.com/terrestris/shogun-demo-client/commit/0523b77d52f142593cd1d82e63e210b770d9ae39))
-* **deps-dev:** bump @babel/preset-env from 7.18.6 to 7.18.9 ([32f2c94](https://github.com/terrestris/shogun-demo-client/commit/32f2c947d6c075260dff473857a7cc04b97d698f))
-* **deps-dev:** bump @playwright/test from 1.23.2 to 1.23.4 ([859de2c](https://github.com/terrestris/shogun-demo-client/commit/859de2c7d529dd94408c09cf29fd45dadc43dae6))
-* **deps-dev:** bump @playwright/test from 1.23.4 to 1.24.0 ([f6a13bd](https://github.com/terrestris/shogun-demo-client/commit/f6a13bd100f591f91728d04cac9f7e5faeb4535c))
-* **deps-dev:** bump @playwright/test from 1.24.0 to 1.24.1 ([706e30c](https://github.com/terrestris/shogun-demo-client/commit/706e30cc1a096fd3835fe9a7516bfc8dec2bdcfd))
-* **deps-dev:** bump @typescript-eslint/eslint-plugin ([1585157](https://github.com/terrestris/shogun-demo-client/commit/15851578630be8b71e452c9b43fa0a1ecf8afd96))
-* **deps-dev:** bump @typescript-eslint/eslint-plugin ([a7e4ea4](https://github.com/terrestris/shogun-demo-client/commit/a7e4ea4c35132198122a51fba85d7ffcd55a0d32))
-* **deps-dev:** bump @typescript-eslint/eslint-plugin ([b23098d](https://github.com/terrestris/shogun-demo-client/commit/b23098d12bf398c15e139127ff7036675e3cc5d5))
-* **deps-dev:** bump @typescript-eslint/parser from 5.30.5 to 5.30.6 ([3bd08d9](https://github.com/terrestris/shogun-demo-client/commit/3bd08d97dffcf462813832eb9c247367540d95aa))
-* **deps-dev:** bump @typescript-eslint/parser from 5.30.6 to 5.30.7 ([67f9ded](https://github.com/terrestris/shogun-demo-client/commit/67f9dedf3533e09033a14ba2eeb1b4e41e5d0c03))
-* **deps-dev:** bump @typescript-eslint/parser from 5.30.7 to 5.31.0 ([59eae8c](https://github.com/terrestris/shogun-demo-client/commit/59eae8c26cbc47210ed3aa0198cd10d7d92afb73))
-* **deps-dev:** bump eslint from 8.19.0 to 8.20.0 ([26ae94d](https://github.com/terrestris/shogun-demo-client/commit/26ae94dce9487d9e77de2673a81859f78fc39eeb))
-* **deps-dev:** bump jest and @types/jest ([cf08d99](https://github.com/terrestris/shogun-demo-client/commit/cf08d994a22544b2ab9025891e607f888552c777))
-* **deps-dev:** bump jest-environment-jsdom from 28.1.2 to 28.1.3 ([d904c83](https://github.com/terrestris/shogun-demo-client/commit/d904c83f23ab14d1e2b5bbbcdc2f3a88fe04b93c))
-* **deps-dev:** bump webpack from 5.73.0 to 5.74.0 ([f17da3a](https://github.com/terrestris/shogun-demo-client/commit/f17da3a5f61b8e4e21bbf76362100d6b1418cb20))
-* **deps:** bump @terrestris/react-geo from 17.4.1 to 17.5.0 ([8c5f242](https://github.com/terrestris/shogun-demo-client/commit/8c5f24281ec827712c506a80e0b0278a563a9845))
-* **deps:** bump @terrestris/react-geo from 19.0.0 to 19.1.0 ([b36bec5](https://github.com/terrestris/shogun-demo-client/commit/b36bec5cac0baaacebef4442c854dd113cd2951d))
-* **deps:** bump @terrestris/react-geo from 19.1.0 to 19.1.1 ([9c4da40](https://github.com/terrestris/shogun-demo-client/commit/9c4da40706a2225c904d0ba71f43d8d4e5246fad))
-* **deps:** bump antd from 4.21.5 to 4.21.7 ([9aab769](https://github.com/terrestris/shogun-demo-client/commit/9aab769a92a8553bafb3d267ca36e7acba7dabb5))
-* **deps:** bump antd from 4.21.7 to 4.22.0 ([3f99355](https://github.com/terrestris/shogun-demo-client/commit/3f9935516256fa72addc3a016942312999bb95c5))
-* **deps:** bump antd from 4.22.0 to 4.22.1 ([e6fdade](https://github.com/terrestris/shogun-demo-client/commit/e6fdadef0af57a22bc3d9f1f8886b3c8107f0c5e))
-* **deps:** bump i18next from 21.8.13 to 21.8.14 ([98195cb](https://github.com/terrestris/shogun-demo-client/commit/98195cb93851c27ccbafc72e96e2f072b3f89c1a))
-* **deps:** bump react-i18next from 11.18.0 to 11.18.1 ([db2545f](https://github.com/terrestris/shogun-demo-client/commit/db2545fbeaccf96662fb26dda4506abeb216ddd3))
-* **deps:** bump react-i18next from 11.18.1 to 11.18.3 ([4739e06](https://github.com/terrestris/shogun-demo-client/commit/4739e06cd5e9e8c0b34ffda4814e2175a40854e9))
-* **draw-export:** added translations ([5755bc1](https://github.com/terrestris/shogun-demo-client/commit/5755bc1eb8968e547f9c11c4f2d442e9ed63f5b9))
-* **draw:** added missing file ([d928b85](https://github.com/terrestris/shogun-demo-client/commit/d928b85cfaa70f7af9f22d408bc0e90d2feba319))
-* **draw:** condensed if conditions in one if statement ([f6a8451](https://github.com/terrestris/shogun-demo-client/commit/f6a8451f3856a095d4a43deafcca40b02395b736))
-* **draw:** fixed bug that was selecting modify and delete at the same time ([28faedf](https://github.com/terrestris/shogun-demo-client/commit/28faedf9db92b740f1caca377eaeaa70c05eeb84))
-* **draw:** uploaded data is now transformed to map projection, cleanup ([aecc3f0](https://github.com/terrestris/shogun-demo-client/commit/aecc3f0336b3541f091c7c2f18896f44932f077d))
-* **unit-tests:** added basic rendering unit tests to all components ([3bf444c](https://github.com/terrestris/shogun-demo-client/commit/3bf444c88b3e615d05e369f71d9e39046ef6aff6))
-* **unit-tests:** added missing files ([ef3fd9c](https://github.com/terrestris/shogun-demo-client/commit/ef3fd9c65dcb3e4a7ddabd8f815c84cad3ed5aee))
-* **unit-tests:** removed uneeded comments ([e86de02](https://github.com/terrestris/shogun-demo-client/commit/e86de0289d6c97a74721c586ffc03aa736f825f0))
-* update react-geo ([e065bdd](https://github.com/terrestris/shogun-demo-client/commit/e065bddd42244991ca4baa8e7821edac801392d8))
-* update README ([1b57ceb](https://github.com/terrestris/shogun-demo-client/commit/1b57ceb1f99fb2ddb32aba9603f1eaecdd592c32))
-* update shogun-util ([8cd7c76](https://github.com/terrestris/shogun-demo-client/commit/8cd7c76dab166081fe422e4c3a65be17bd695338))
+* **deps-dev:** bump @babel/core from 7.18.6 to 7.18.9 ([0523b77](https://github.com/terrestris/shogun-gis-client/commit/0523b77d52f142593cd1d82e63e210b770d9ae39))
+* **deps-dev:** bump @babel/preset-env from 7.18.6 to 7.18.9 ([32f2c94](https://github.com/terrestris/shogun-gis-client/commit/32f2c947d6c075260dff473857a7cc04b97d698f))
+* **deps-dev:** bump @playwright/test from 1.23.2 to 1.23.4 ([859de2c](https://github.com/terrestris/shogun-gis-client/commit/859de2c7d529dd94408c09cf29fd45dadc43dae6))
+* **deps-dev:** bump @playwright/test from 1.23.4 to 1.24.0 ([f6a13bd](https://github.com/terrestris/shogun-gis-client/commit/f6a13bd100f591f91728d04cac9f7e5faeb4535c))
+* **deps-dev:** bump @playwright/test from 1.24.0 to 1.24.1 ([706e30c](https://github.com/terrestris/shogun-gis-client/commit/706e30cc1a096fd3835fe9a7516bfc8dec2bdcfd))
+* **deps-dev:** bump @typescript-eslint/eslint-plugin ([1585157](https://github.com/terrestris/shogun-gis-client/commit/15851578630be8b71e452c9b43fa0a1ecf8afd96))
+* **deps-dev:** bump @typescript-eslint/eslint-plugin ([a7e4ea4](https://github.com/terrestris/shogun-gis-client/commit/a7e4ea4c35132198122a51fba85d7ffcd55a0d32))
+* **deps-dev:** bump @typescript-eslint/eslint-plugin ([b23098d](https://github.com/terrestris/shogun-gis-client/commit/b23098d12bf398c15e139127ff7036675e3cc5d5))
+* **deps-dev:** bump @typescript-eslint/parser from 5.30.5 to 5.30.6 ([3bd08d9](https://github.com/terrestris/shogun-gis-client/commit/3bd08d97dffcf462813832eb9c247367540d95aa))
+* **deps-dev:** bump @typescript-eslint/parser from 5.30.6 to 5.30.7 ([67f9ded](https://github.com/terrestris/shogun-gis-client/commit/67f9dedf3533e09033a14ba2eeb1b4e41e5d0c03))
+* **deps-dev:** bump @typescript-eslint/parser from 5.30.7 to 5.31.0 ([59eae8c](https://github.com/terrestris/shogun-gis-client/commit/59eae8c26cbc47210ed3aa0198cd10d7d92afb73))
+* **deps-dev:** bump eslint from 8.19.0 to 8.20.0 ([26ae94d](https://github.com/terrestris/shogun-gis-client/commit/26ae94dce9487d9e77de2673a81859f78fc39eeb))
+* **deps-dev:** bump jest and @types/jest ([cf08d99](https://github.com/terrestris/shogun-gis-client/commit/cf08d994a22544b2ab9025891e607f888552c777))
+* **deps-dev:** bump jest-environment-jsdom from 28.1.2 to 28.1.3 ([d904c83](https://github.com/terrestris/shogun-gis-client/commit/d904c83f23ab14d1e2b5bbbcdc2f3a88fe04b93c))
+* **deps-dev:** bump webpack from 5.73.0 to 5.74.0 ([f17da3a](https://github.com/terrestris/shogun-gis-client/commit/f17da3a5f61b8e4e21bbf76362100d6b1418cb20))
+* **deps:** bump @terrestris/react-geo from 17.4.1 to 17.5.0 ([8c5f242](https://github.com/terrestris/shogun-gis-client/commit/8c5f24281ec827712c506a80e0b0278a563a9845))
+* **deps:** bump @terrestris/react-geo from 19.0.0 to 19.1.0 ([b36bec5](https://github.com/terrestris/shogun-gis-client/commit/b36bec5cac0baaacebef4442c854dd113cd2951d))
+* **deps:** bump @terrestris/react-geo from 19.1.0 to 19.1.1 ([9c4da40](https://github.com/terrestris/shogun-gis-client/commit/9c4da40706a2225c904d0ba71f43d8d4e5246fad))
+* **deps:** bump antd from 4.21.5 to 4.21.7 ([9aab769](https://github.com/terrestris/shogun-gis-client/commit/9aab769a92a8553bafb3d267ca36e7acba7dabb5))
+* **deps:** bump antd from 4.21.7 to 4.22.0 ([3f99355](https://github.com/terrestris/shogun-gis-client/commit/3f9935516256fa72addc3a016942312999bb95c5))
+* **deps:** bump antd from 4.22.0 to 4.22.1 ([e6fdade](https://github.com/terrestris/shogun-gis-client/commit/e6fdadef0af57a22bc3d9f1f8886b3c8107f0c5e))
+* **deps:** bump i18next from 21.8.13 to 21.8.14 ([98195cb](https://github.com/terrestris/shogun-gis-client/commit/98195cb93851c27ccbafc72e96e2f072b3f89c1a))
+* **deps:** bump react-i18next from 11.18.0 to 11.18.1 ([db2545f](https://github.com/terrestris/shogun-gis-client/commit/db2545fbeaccf96662fb26dda4506abeb216ddd3))
+* **deps:** bump react-i18next from 11.18.1 to 11.18.3 ([4739e06](https://github.com/terrestris/shogun-gis-client/commit/4739e06cd5e9e8c0b34ffda4814e2175a40854e9))
+* **draw-export:** added translations ([5755bc1](https://github.com/terrestris/shogun-gis-client/commit/5755bc1eb8968e547f9c11c4f2d442e9ed63f5b9))
+* **draw:** added missing file ([d928b85](https://github.com/terrestris/shogun-gis-client/commit/d928b85cfaa70f7af9f22d408bc0e90d2feba319))
+* **draw:** condensed if conditions in one if statement ([f6a8451](https://github.com/terrestris/shogun-gis-client/commit/f6a8451f3856a095d4a43deafcca40b02395b736))
+* **draw:** fixed bug that was selecting modify and delete at the same time ([28faedf](https://github.com/terrestris/shogun-gis-client/commit/28faedf9db92b740f1caca377eaeaa70c05eeb84))
+* **draw:** uploaded data is now transformed to map projection, cleanup ([aecc3f0](https://github.com/terrestris/shogun-gis-client/commit/aecc3f0336b3541f091c7c2f18896f44932f077d))
+* **unit-tests:** added basic rendering unit tests to all components ([3bf444c](https://github.com/terrestris/shogun-gis-client/commit/3bf444c88b3e615d05e369f71d9e39046ef6aff6))
+* **unit-tests:** added missing files ([ef3fd9c](https://github.com/terrestris/shogun-gis-client/commit/ef3fd9c65dcb3e4a7ddabd8f815c84cad3ed5aee))
+* **unit-tests:** removed uneeded comments ([e86de02](https://github.com/terrestris/shogun-gis-client/commit/e86de0289d6c97a74721c586ffc03aa736f825f0))
+* update react-geo ([e065bdd](https://github.com/terrestris/shogun-gis-client/commit/e065bddd42244991ca4baa8e7821edac801392d8))
+* update README ([1b57ceb](https://github.com/terrestris/shogun-gis-client/commit/1b57ceb1f99fb2ddb32aba9603f1eaecdd592c32))
+* update shogun-util ([8cd7c76](https://github.com/terrestris/shogun-gis-client/commit/8cd7c76dab166081fe422e4c3a65be17bd695338))
 
-## [3.2.0](https://github.com/terrestris/shogun-demo-client/compare/v3.1.1...v3.2.0) (2022-07-08)
+## [3.2.0](https://github.com/terrestris/shogun-gis-client/compare/v3.1.1...v3.2.0) (2022-07-08)
 
 
 ### Features
 
-* add appInfo to store ([6d2cf6c](https://github.com/terrestris/shogun-demo-client/commit/6d2cf6c3e4757cc22db7af1655b0d3a41521d262))
-* add ApplicationInfo component ([b6ce163](https://github.com/terrestris/shogun-demo-client/commit/b6ce1639138f3d577c8dbb0c292574dc5b899ce4))
-* add getGravatarUrl util ([6e460c2](https://github.com/terrestris/shogun-demo-client/commit/6e460c2541505e068d40b647daf66207eb9d2003))
-* add user to state ([c38e5f8](https://github.com/terrestris/shogun-demo-client/commit/c38e5f84fb5aec359140915744cc579e67cd32d4))
-* add UserMenu component ([3bfcb9a](https://github.com/terrestris/shogun-demo-client/commit/3bfcb9a9e4b1c5a124e349ee360c31d76abe9dbc))
-* fetch and set applicationInfo and user to store and initialize keycloak adapter if needed ([416abf8](https://github.com/terrestris/shogun-demo-client/commit/416abf83a9b0dfdaab38a3c1971d9f780f0072d1))
-* hide the loading mask on init ([9e23a39](https://github.com/terrestris/shogun-demo-client/commit/9e23a390ea139c21e0549ee0d263f4f22408ee5c))
-* show the UserMenu in header ([f6d6a2f](https://github.com/terrestris/shogun-demo-client/commit/f6d6a2f44f3fbaeafb1aa0e8ceba31b701c925c0))
+* add appInfo to store ([6d2cf6c](https://github.com/terrestris/shogun-gis-client/commit/6d2cf6c3e4757cc22db7af1655b0d3a41521d262))
+* add ApplicationInfo component ([b6ce163](https://github.com/terrestris/shogun-gis-client/commit/b6ce1639138f3d577c8dbb0c292574dc5b899ce4))
+* add getGravatarUrl util ([6e460c2](https://github.com/terrestris/shogun-gis-client/commit/6e460c2541505e068d40b647daf66207eb9d2003))
+* add user to state ([c38e5f8](https://github.com/terrestris/shogun-gis-client/commit/c38e5f84fb5aec359140915744cc579e67cd32d4))
+* add UserMenu component ([3bfcb9a](https://github.com/terrestris/shogun-gis-client/commit/3bfcb9a9e4b1c5a124e349ee360c31d76abe9dbc))
+* fetch and set applicationInfo and user to store and initialize keycloak adapter if needed ([416abf8](https://github.com/terrestris/shogun-gis-client/commit/416abf83a9b0dfdaab38a3c1971d9f780f0072d1))
+* hide the loading mask on init ([9e23a39](https://github.com/terrestris/shogun-gis-client/commit/9e23a390ea139c21e0549ee0d263f4f22408ee5c))
+* show the UserMenu in header ([f6d6a2f](https://github.com/terrestris/shogun-gis-client/commit/f6d6a2f44f3fbaeafb1aa0e8ceba31b701c925c0))
 
 
 ### Changes in configuration
 
-* change release workflow to be manually ([4a7e653](https://github.com/terrestris/shogun-demo-client/commit/4a7e653f0f305fcbfba45d381b5d48c18b3bd0d9))
+* change release workflow to be manually ([4a7e653](https://github.com/terrestris/shogun-gis-client/commit/4a7e653f0f305fcbfba45d381b5d48c18b3bd0d9))
 
 
 ### Changes in layout
 
-* enhance loading animation ([02d43db](https://github.com/terrestris/shogun-demo-client/commit/02d43db66380b3847a8fee8b5a747e041eebf27d))
+* enhance loading animation ([02d43db](https://github.com/terrestris/shogun-gis-client/commit/02d43db66380b3847a8fee8b5a747e041eebf27d))
 
 
 ### Bugfixes
 
-* accept full url ([2575e81](https://github.com/terrestris/shogun-demo-client/commit/2575e819c9d4343f4a2bc16a1e3c9c63304ff720))
-* add missing translation key ([bac68a6](https://github.com/terrestris/shogun-demo-client/commit/bac68a6a1de122b4328d7f25b117465292004f9f))
-* get client config from relative path ([5bc0b14](https://github.com/terrestris/shogun-demo-client/commit/5bc0b14430d62756418ed7c1914e6f76858d1d29))
-* make use of changed shogun client name ([ad4c7c0](https://github.com/terrestris/shogun-demo-client/commit/ad4c7c0bf37d37ebd146d6e9fcbfd9046fa7c2ff))
-* remove unneeded util class ([9e1e514](https://github.com/terrestris/shogun-demo-client/commit/9e1e514a3b3f2c01ef432dc47873227b4a93a9d4))
-* set correct default logo path ([4adae28](https://github.com/terrestris/shogun-demo-client/commit/4adae28fa43933913d6bb3206205d74afc4b4fb1))
-* support print for internal layers ([17dcc99](https://github.com/terrestris/shogun-demo-client/commit/17dcc996280e6c3a56d1a3c63a547badfa2b076d))
-* wait until at least the map is visible before performing checks ([a8fd7d7](https://github.com/terrestris/shogun-demo-client/commit/a8fd7d773afa70d3035cc66d4036397a6ece5298))
+* accept full url ([2575e81](https://github.com/terrestris/shogun-gis-client/commit/2575e819c9d4343f4a2bc16a1e3c9c63304ff720))
+* add missing translation key ([bac68a6](https://github.com/terrestris/shogun-gis-client/commit/bac68a6a1de122b4328d7f25b117465292004f9f))
+* get client config from relative path ([5bc0b14](https://github.com/terrestris/shogun-gis-client/commit/5bc0b14430d62756418ed7c1914e6f76858d1d29))
+* make use of changed shogun client name ([ad4c7c0](https://github.com/terrestris/shogun-gis-client/commit/ad4c7c0bf37d37ebd146d6e9fcbfd9046fa7c2ff))
+* remove unneeded util class ([9e1e514](https://github.com/terrestris/shogun-gis-client/commit/9e1e514a3b3f2c01ef432dc47873227b4a93a9d4))
+* set correct default logo path ([4adae28](https://github.com/terrestris/shogun-gis-client/commit/4adae28fa43933913d6bb3206205d74afc4b4fb1))
+* support print for internal layers ([17dcc99](https://github.com/terrestris/shogun-gis-client/commit/17dcc996280e6c3a56d1a3c63a547badfa2b076d))
+* wait until at least the map is visible before performing checks ([a8fd7d7](https://github.com/terrestris/shogun-gis-client/commit/a8fd7d773afa70d3035cc66d4036397a6ece5298))
 
 
 ### Dependencies
 
-* add keycloak-js and js-md5 dependencies ([5d74bda](https://github.com/terrestris/shogun-demo-client/commit/5d74bdad5df629768de1bb09a08b0951d9ce0fe8))
-* add mock for matchMedia ([c120cc6](https://github.com/terrestris/shogun-demo-client/commit/c120cc63fe42b9f90545b877e27c1446fc92d027))
-* **deps-dev:** bump @babel/core from 7.18.2 to 7.18.5 ([f4f2dcb](https://github.com/terrestris/shogun-demo-client/commit/f4f2dcb5debfe96f8ae65e46bbc40414c70f7e27))
-* **deps-dev:** bump @babel/core from 7.18.5 to 7.18.6 ([ac0df40](https://github.com/terrestris/shogun-demo-client/commit/ac0df4050a997061a1b3df17ca1b4f1213431219))
-* **deps-dev:** bump @babel/preset-env from 7.18.2 to 7.18.6 ([8ae4792](https://github.com/terrestris/shogun-demo-client/commit/8ae4792dde26fe497e0f194af02ece116cfa3b75))
-* **deps-dev:** bump @babel/preset-react from 7.17.12 to 7.18.6 ([5b59a25](https://github.com/terrestris/shogun-demo-client/commit/5b59a259d59c33def062e72da3b49c575c872549))
-* **deps-dev:** bump @babel/preset-typescript from 7.17.12 to 7.18.6 ([9755a97](https://github.com/terrestris/shogun-demo-client/commit/9755a97af38c3d695261f020e5b20ef40206ad2f))
-* **deps-dev:** bump @commitlint/cli from 17.0.1 to 17.0.2 ([16d6d4c](https://github.com/terrestris/shogun-demo-client/commit/16d6d4c622798df448302ad80b5f3bfb4cf8ba25))
-* **deps-dev:** bump @commitlint/cli from 17.0.2 to 17.0.3 ([acfb338](https://github.com/terrestris/shogun-demo-client/commit/acfb3384739c773dddb183769dc3b3f2d5ba217e))
-* **deps-dev:** bump @commitlint/config-conventional ([1b4a3e8](https://github.com/terrestris/shogun-demo-client/commit/1b4a3e8d5454138e29beb804d0af6708c94e1d05))
-* **deps-dev:** bump @commitlint/config-conventional ([30a9585](https://github.com/terrestris/shogun-demo-client/commit/30a9585481f70b9a01c3e6de4fcc9774f8f18bc4))
-* **deps-dev:** bump @playwright/test from 1.22.2 to 1.23.0 ([33b5fcc](https://github.com/terrestris/shogun-demo-client/commit/33b5fcc2fa3d2e7e5b50c9a98078ad4ecf714bb6))
-* **deps-dev:** bump @playwright/test from 1.23.0 to 1.23.1 ([2fce9da](https://github.com/terrestris/shogun-demo-client/commit/2fce9dabd6b28e91018eced06649307c8f326126))
-* **deps-dev:** bump @playwright/test from 1.23.1 to 1.23.2 ([50aac6d](https://github.com/terrestris/shogun-demo-client/commit/50aac6d849d9334023848757c43a5c5f061eb5eb))
-* **deps-dev:** bump @semantic-release/github from 8.0.4 to 8.0.5 ([5d56b51](https://github.com/terrestris/shogun-demo-client/commit/5d56b51edada36a409a1715b2c733f1fafd7c175))
-* **deps-dev:** bump @terrestris/eslint-config-typescript ([81f2832](https://github.com/terrestris/shogun-demo-client/commit/81f2832c1a4a15c31e9cad655ba5fc2b5b7003eb))
-* **deps-dev:** bump @types/jest from 27.5.1 to 28.1.0 ([33c808a](https://github.com/terrestris/shogun-demo-client/commit/33c808a232f479c390aeda01cf2bd185c7df924d))
-* **deps-dev:** bump @types/jest from 28.1.2 to 28.1.3 ([df4b731](https://github.com/terrestris/shogun-demo-client/commit/df4b731f6190b16bc5617f7b5ac884ba70ea5011))
-* **deps-dev:** bump @typescript-eslint/eslint-plugin ([46eb547](https://github.com/terrestris/shogun-demo-client/commit/46eb547643dc5a64282f03030254bc919706aef4))
-* **deps-dev:** bump @typescript-eslint/eslint-plugin ([e5ac89d](https://github.com/terrestris/shogun-demo-client/commit/e5ac89d90a6d4b70b16ea436696496b6b1c90120))
-* **deps-dev:** bump @typescript-eslint/eslint-plugin ([675fe52](https://github.com/terrestris/shogun-demo-client/commit/675fe524992c2a102b86f642e7d274add961da74))
-* **deps-dev:** bump @typescript-eslint/eslint-plugin ([a8598cd](https://github.com/terrestris/shogun-demo-client/commit/a8598cdd3bdcb387c07d42184f57018748d2462c))
-* **deps-dev:** bump @typescript-eslint/eslint-plugin ([f32a0cd](https://github.com/terrestris/shogun-demo-client/commit/f32a0cd78ae0f0b673a55c04159c101ab8da922c))
-* **deps-dev:** bump @typescript-eslint/parser from 5.27.0 to 5.27.1 ([cb63437](https://github.com/terrestris/shogun-demo-client/commit/cb63437cc77875fb0aeee5d906caba7852e51958))
-* **deps-dev:** bump @typescript-eslint/parser from 5.27.1 to 5.28.0 ([a9d8407](https://github.com/terrestris/shogun-demo-client/commit/a9d840702af070fb8831a6458c0eae94b79e3aec))
-* **deps-dev:** bump @typescript-eslint/parser from 5.28.0 to 5.29.0 ([39fab76](https://github.com/terrestris/shogun-demo-client/commit/39fab76a0f2832c9277568f6e2853d555b05daf1))
-* **deps-dev:** bump @typescript-eslint/parser from 5.29.0 to 5.30.0 ([67d370a](https://github.com/terrestris/shogun-demo-client/commit/67d370a0b6f2d3a58b3f4a1c18f7cf9f9b87d7fc))
-* **deps-dev:** bump @typescript-eslint/parser from 5.30.0 to 5.30.5 ([e7118b4](https://github.com/terrestris/shogun-demo-client/commit/e7118b4472a9462b112906c7d8f4c705b5e09cba))
-* **deps-dev:** bump babel-jest from 28.1.0 to 28.1.1 ([e50487f](https://github.com/terrestris/shogun-demo-client/commit/e50487f108138f1d71d70092d1d1d03517c5b361))
-* **deps-dev:** bump babel-jest from 28.1.1 to 28.1.2 ([a3b4d45](https://github.com/terrestris/shogun-demo-client/commit/a3b4d45f591691b4d56300dd35fdbeb7dee13f65))
-* **deps-dev:** bump eslint from 8.16.0 to 8.17.0 ([24fd1f1](https://github.com/terrestris/shogun-demo-client/commit/24fd1f1c6d6c173e3cb56d9e5f3758e4afa64bd2))
-* **deps-dev:** bump eslint from 8.17.0 to 8.18.0 ([c846fca](https://github.com/terrestris/shogun-demo-client/commit/c846fcab274e7c9589f6ebc0d006f9645c9c92ce))
-* **deps-dev:** bump eslint from 8.18.0 to 8.19.0 ([f734c01](https://github.com/terrestris/shogun-demo-client/commit/f734c01017f883e49c243bfbe4cd08cf82c41818))
-* **deps-dev:** bump eslint-plugin-react from 7.30.0 to 7.30.1 ([2199fd1](https://github.com/terrestris/shogun-demo-client/commit/2199fd144c9ec4e2f22ebe6ebcde85b03c9aeb41))
-* **deps-dev:** bump jest and @types/jest ([12170a6](https://github.com/terrestris/shogun-demo-client/commit/12170a65b545d6d577eae9556b300757d1c71bd7))
-* **deps-dev:** bump jest and @types/jest ([149b84d](https://github.com/terrestris/shogun-demo-client/commit/149b84da8539c612571465ba5100bd4eeb929afb))
-* **deps-dev:** bump jest-environment-jsdom from 28.1.0 to 28.1.1 ([8c072a5](https://github.com/terrestris/shogun-demo-client/commit/8c072a524b68498b79959699cb30ff4de5880a30))
-* **deps-dev:** bump jest-environment-jsdom from 28.1.1 to 28.1.2 ([1eba66a](https://github.com/terrestris/shogun-demo-client/commit/1eba66a4368cbb5e37e37c9c7f04930a7741b42a))
-* **deps-dev:** bump less from 4.1.2 to 4.1.3 ([24c3d9f](https://github.com/terrestris/shogun-demo-client/commit/24c3d9ffa019557e0746a2801729a19ab13f4eed))
-* **deps-dev:** bump mini-css-extract-plugin from 2.6.0 to 2.6.1 ([14000c8](https://github.com/terrestris/shogun-demo-client/commit/14000c8c81910c66e7afbf943cbb034d284b94ac))
-* **deps-dev:** bump react-refresh from 0.13.0 to 0.14.0 ([7c3a313](https://github.com/terrestris/shogun-demo-client/commit/7c3a313a1a1b3803e73433be48035b702b83107c))
-* **deps-dev:** bump semantic-release from 19.0.2 to 19.0.3 ([0cea4e5](https://github.com/terrestris/shogun-demo-client/commit/0cea4e584f8eefced85c9c1c24f821fe34d4c8b4))
-* **deps-dev:** bump terser-webpack-plugin from 5.3.1 to 5.3.3 ([a44a734](https://github.com/terrestris/shogun-demo-client/commit/a44a734cc85cc1aac2bcc17c3127031250817c03))
-* **deps-dev:** bump typescript from 4.7.2 to 4.7.3 ([12d04e6](https://github.com/terrestris/shogun-demo-client/commit/12d04e6f8fbc34c08976045fd7b9e678d527ba4c))
-* **deps-dev:** bump typescript from 4.7.3 to 4.7.4 ([283e13b](https://github.com/terrestris/shogun-demo-client/commit/283e13b4f5743acbc6244142f4a874adfe323850))
-* **deps-dev:** bump webpack from 5.72.1 to 5.73.0 ([72526f9](https://github.com/terrestris/shogun-demo-client/commit/72526f9e914d4b6aafa70298255625460d87a4db))
-* **deps-dev:** bump webpack-cli from 4.9.2 to 4.10.0 ([c6ed2fd](https://github.com/terrestris/shogun-demo-client/commit/c6ed2fd3ebe515c36c59037fa514c74f4c7699dd))
-* **deps-dev:** bump webpack-dev-server from 4.9.0 to 4.9.1 ([5860ef6](https://github.com/terrestris/shogun-demo-client/commit/5860ef6a946662911c039e7af0964bfa5b0438ab))
-* **deps-dev:** bump webpack-dev-server from 4.9.1 to 4.9.2 ([d36c8de](https://github.com/terrestris/shogun-demo-client/commit/d36c8de03e82ba2ce409f36436361ba7e4c8d4fe))
-* **deps-dev:** bump webpack-dev-server from 4.9.2 to 4.9.3 ([30573aa](https://github.com/terrestris/shogun-demo-client/commit/30573aa0dd914d12b55683e4c01636bad07e69a8))
-* **deps:** bump @reduxjs/toolkit from 1.8.2 to 1.8.3 ([927d53b](https://github.com/terrestris/shogun-demo-client/commit/927d53bf7f079de2d0811703999e027302289385))
-* **deps:** bump @terrestris/react-geo from 17.1.3 to 17.2.1 ([b485c4b](https://github.com/terrestris/shogun-demo-client/commit/b485c4bb461965b4072b0a8a6665391e732d8424))
-* **deps:** bump @terrestris/react-geo from 17.2.1 to 17.2.2 ([ed32d6a](https://github.com/terrestris/shogun-demo-client/commit/ed32d6ac60dd87bd02f11f1badd60001f343bf9c))
-* **deps:** bump @terrestris/react-geo from 17.2.2 to 17.3.0 ([8fbd893](https://github.com/terrestris/shogun-demo-client/commit/8fbd893f1da7e740b9ed4d14b2f10bf58423c2c2))
-* **deps:** bump @terrestris/react-geo from 17.3.0 to 17.3.1 ([559030e](https://github.com/terrestris/shogun-demo-client/commit/559030ed803cb64a2b7b82a15945fb443df77bf8))
-* **deps:** bump @terrestris/react-geo from 17.3.1 to 17.4.1 ([21ac106](https://github.com/terrestris/shogun-demo-client/commit/21ac1064d621bcac39d75cf488b50406b6cbe14e))
-* **deps:** bump @terrestris/shogun-util from 1.0.1 to 1.1.0 ([9dcb73e](https://github.com/terrestris/shogun-demo-client/commit/9dcb73e22e3111b582c53e12dabe396e7b3ee615))
-* **deps:** bump @terrestris/shogun-util from 1.1.0 to 1.2.1 ([d837f43](https://github.com/terrestris/shogun-demo-client/commit/d837f432a879c919cc6df5a3878cb7631340c7cd))
-* **deps:** bump @terrestris/shogun-util from 2.0.0 to 3.0.0 ([354fa96](https://github.com/terrestris/shogun-demo-client/commit/354fa96da4bf25d9081db49614e80706c1a7ce03))
-* **deps:** bump @terrestris/shogun-util from 3.0.0 to 3.1.2 ([d426116](https://github.com/terrestris/shogun-demo-client/commit/d42611606858028483f7adf192f31ac37a04c225))
-* **deps:** bump antd from 4.20.7 to 4.21.0 ([ecb4d02](https://github.com/terrestris/shogun-demo-client/commit/ecb4d028853192ce10ad024ccece6585edb682f6))
-* **deps:** bump antd from 4.21.0 to 4.21.1 ([3a379b3](https://github.com/terrestris/shogun-demo-client/commit/3a379b3f394b874ecec1586a0415e16634cbb904))
-* **deps:** bump antd from 4.21.1 to 4.21.3 ([5901460](https://github.com/terrestris/shogun-demo-client/commit/59014606f4df0b63c2c98651ecde9134e194dfe6))
-* **deps:** bump antd from 4.21.3 to 4.21.4 ([9f5e89c](https://github.com/terrestris/shogun-demo-client/commit/9f5e89c85919eec36f72726e1a89549923ff2cc1))
-* **deps:** bump antd from 4.21.4 to 4.21.5 ([9acb16a](https://github.com/terrestris/shogun-demo-client/commit/9acb16a5fdf8b920dd6399e5f2223390794fdee7))
-* **deps:** bump i18next from 21.8.10 to 21.8.11 ([b72ce14](https://github.com/terrestris/shogun-demo-client/commit/b72ce1449ad340f9ff679b6faabb2fbaef2a1ff2))
-* **deps:** bump i18next from 21.8.11 to 21.8.12 ([4a21c18](https://github.com/terrestris/shogun-demo-client/commit/4a21c18c88f0258e4be4031310445a1a85367070))
-* **deps:** bump i18next from 21.8.12 to 21.8.13 ([9b0014c](https://github.com/terrestris/shogun-demo-client/commit/9b0014c1a6c71b6368f92fd5de66309da351b56b))
-* **deps:** bump i18next from 21.8.5 to 21.8.8 ([bdf517c](https://github.com/terrestris/shogun-demo-client/commit/bdf517cfc8b10208f31839eb2f66389f16e32d08))
-* **deps:** bump i18next from 21.8.8 to 21.8.9 ([aabead9](https://github.com/terrestris/shogun-demo-client/commit/aabead959c86665e6a3fb57ad72187782feed572))
-* **deps:** bump i18next from 21.8.9 to 21.8.10 ([be13c25](https://github.com/terrestris/shogun-demo-client/commit/be13c25a67b77a93229b62281836798ca9de6331))
-* **deps:** bump react-i18next from 11.16.9 to 11.17.0 ([bdd6d6a](https://github.com/terrestris/shogun-demo-client/commit/bdd6d6aebff7d45d72e82e1885e15cec1b8af794))
-* **deps:** bump react-i18next from 11.17.0 to 11.17.1 ([e532b15](https://github.com/terrestris/shogun-demo-client/commit/e532b15216d5fc54978e256a31ef7d18e5c24553))
-* **deps:** bump react-i18next from 11.17.1 to 11.17.2 ([25113dc](https://github.com/terrestris/shogun-demo-client/commit/25113dcf12dd7c116c59c519556eca56c51b6eea))
-* **deps:** bump react-i18next from 11.17.2 to 11.17.3 ([2b7e28e](https://github.com/terrestris/shogun-demo-client/commit/2b7e28e0f095b5f6a504f6214130337c20f275df))
-* **deps:** bump react-i18next from 11.17.3 to 11.17.4 ([74c499b](https://github.com/terrestris/shogun-demo-client/commit/74c499bd314bfd610efcab138fce4926627021e8))
-* **deps:** bump react-i18next from 11.17.4 to 11.18.0 ([e14fcf3](https://github.com/terrestris/shogun-demo-client/commit/e14fcf3a4ddede21db867f99620208762a287f09))
-* update to the latest shogun-util ([e6ec46b](https://github.com/terrestris/shogun-demo-client/commit/e6ec46b958c3c02864a4120ec59d011302b7e004))
-* update translations ([9f40e8e](https://github.com/terrestris/shogun-demo-client/commit/9f40e8e5808036f7cca56f15b84bee092f1cccbe))
+* add keycloak-js and js-md5 dependencies ([5d74bda](https://github.com/terrestris/shogun-gis-client/commit/5d74bdad5df629768de1bb09a08b0951d9ce0fe8))
+* add mock for matchMedia ([c120cc6](https://github.com/terrestris/shogun-gis-client/commit/c120cc63fe42b9f90545b877e27c1446fc92d027))
+* **deps-dev:** bump @babel/core from 7.18.2 to 7.18.5 ([f4f2dcb](https://github.com/terrestris/shogun-gis-client/commit/f4f2dcb5debfe96f8ae65e46bbc40414c70f7e27))
+* **deps-dev:** bump @babel/core from 7.18.5 to 7.18.6 ([ac0df40](https://github.com/terrestris/shogun-gis-client/commit/ac0df4050a997061a1b3df17ca1b4f1213431219))
+* **deps-dev:** bump @babel/preset-env from 7.18.2 to 7.18.6 ([8ae4792](https://github.com/terrestris/shogun-gis-client/commit/8ae4792dde26fe497e0f194af02ece116cfa3b75))
+* **deps-dev:** bump @babel/preset-react from 7.17.12 to 7.18.6 ([5b59a25](https://github.com/terrestris/shogun-gis-client/commit/5b59a259d59c33def062e72da3b49c575c872549))
+* **deps-dev:** bump @babel/preset-typescript from 7.17.12 to 7.18.6 ([9755a97](https://github.com/terrestris/shogun-gis-client/commit/9755a97af38c3d695261f020e5b20ef40206ad2f))
+* **deps-dev:** bump @commitlint/cli from 17.0.1 to 17.0.2 ([16d6d4c](https://github.com/terrestris/shogun-gis-client/commit/16d6d4c622798df448302ad80b5f3bfb4cf8ba25))
+* **deps-dev:** bump @commitlint/cli from 17.0.2 to 17.0.3 ([acfb338](https://github.com/terrestris/shogun-gis-client/commit/acfb3384739c773dddb183769dc3b3f2d5ba217e))
+* **deps-dev:** bump @commitlint/config-conventional ([1b4a3e8](https://github.com/terrestris/shogun-gis-client/commit/1b4a3e8d5454138e29beb804d0af6708c94e1d05))
+* **deps-dev:** bump @commitlint/config-conventional ([30a9585](https://github.com/terrestris/shogun-gis-client/commit/30a9585481f70b9a01c3e6de4fcc9774f8f18bc4))
+* **deps-dev:** bump @playwright/test from 1.22.2 to 1.23.0 ([33b5fcc](https://github.com/terrestris/shogun-gis-client/commit/33b5fcc2fa3d2e7e5b50c9a98078ad4ecf714bb6))
+* **deps-dev:** bump @playwright/test from 1.23.0 to 1.23.1 ([2fce9da](https://github.com/terrestris/shogun-gis-client/commit/2fce9dabd6b28e91018eced06649307c8f326126))
+* **deps-dev:** bump @playwright/test from 1.23.1 to 1.23.2 ([50aac6d](https://github.com/terrestris/shogun-gis-client/commit/50aac6d849d9334023848757c43a5c5f061eb5eb))
+* **deps-dev:** bump @semantic-release/github from 8.0.4 to 8.0.5 ([5d56b51](https://github.com/terrestris/shogun-gis-client/commit/5d56b51edada36a409a1715b2c733f1fafd7c175))
+* **deps-dev:** bump @terrestris/eslint-config-typescript ([81f2832](https://github.com/terrestris/shogun-gis-client/commit/81f2832c1a4a15c31e9cad655ba5fc2b5b7003eb))
+* **deps-dev:** bump @types/jest from 27.5.1 to 28.1.0 ([33c808a](https://github.com/terrestris/shogun-gis-client/commit/33c808a232f479c390aeda01cf2bd185c7df924d))
+* **deps-dev:** bump @types/jest from 28.1.2 to 28.1.3 ([df4b731](https://github.com/terrestris/shogun-gis-client/commit/df4b731f6190b16bc5617f7b5ac884ba70ea5011))
+* **deps-dev:** bump @typescript-eslint/eslint-plugin ([46eb547](https://github.com/terrestris/shogun-gis-client/commit/46eb547643dc5a64282f03030254bc919706aef4))
+* **deps-dev:** bump @typescript-eslint/eslint-plugin ([e5ac89d](https://github.com/terrestris/shogun-gis-client/commit/e5ac89d90a6d4b70b16ea436696496b6b1c90120))
+* **deps-dev:** bump @typescript-eslint/eslint-plugin ([675fe52](https://github.com/terrestris/shogun-gis-client/commit/675fe524992c2a102b86f642e7d274add961da74))
+* **deps-dev:** bump @typescript-eslint/eslint-plugin ([a8598cd](https://github.com/terrestris/shogun-gis-client/commit/a8598cdd3bdcb387c07d42184f57018748d2462c))
+* **deps-dev:** bump @typescript-eslint/eslint-plugin ([f32a0cd](https://github.com/terrestris/shogun-gis-client/commit/f32a0cd78ae0f0b673a55c04159c101ab8da922c))
+* **deps-dev:** bump @typescript-eslint/parser from 5.27.0 to 5.27.1 ([cb63437](https://github.com/terrestris/shogun-gis-client/commit/cb63437cc77875fb0aeee5d906caba7852e51958))
+* **deps-dev:** bump @typescript-eslint/parser from 5.27.1 to 5.28.0 ([a9d8407](https://github.com/terrestris/shogun-gis-client/commit/a9d840702af070fb8831a6458c0eae94b79e3aec))
+* **deps-dev:** bump @typescript-eslint/parser from 5.28.0 to 5.29.0 ([39fab76](https://github.com/terrestris/shogun-gis-client/commit/39fab76a0f2832c9277568f6e2853d555b05daf1))
+* **deps-dev:** bump @typescript-eslint/parser from 5.29.0 to 5.30.0 ([67d370a](https://github.com/terrestris/shogun-gis-client/commit/67d370a0b6f2d3a58b3f4a1c18f7cf9f9b87d7fc))
+* **deps-dev:** bump @typescript-eslint/parser from 5.30.0 to 5.30.5 ([e7118b4](https://github.com/terrestris/shogun-gis-client/commit/e7118b4472a9462b112906c7d8f4c705b5e09cba))
+* **deps-dev:** bump babel-jest from 28.1.0 to 28.1.1 ([e50487f](https://github.com/terrestris/shogun-gis-client/commit/e50487f108138f1d71d70092d1d1d03517c5b361))
+* **deps-dev:** bump babel-jest from 28.1.1 to 28.1.2 ([a3b4d45](https://github.com/terrestris/shogun-gis-client/commit/a3b4d45f591691b4d56300dd35fdbeb7dee13f65))
+* **deps-dev:** bump eslint from 8.16.0 to 8.17.0 ([24fd1f1](https://github.com/terrestris/shogun-gis-client/commit/24fd1f1c6d6c173e3cb56d9e5f3758e4afa64bd2))
+* **deps-dev:** bump eslint from 8.17.0 to 8.18.0 ([c846fca](https://github.com/terrestris/shogun-gis-client/commit/c846fcab274e7c9589f6ebc0d006f9645c9c92ce))
+* **deps-dev:** bump eslint from 8.18.0 to 8.19.0 ([f734c01](https://github.com/terrestris/shogun-gis-client/commit/f734c01017f883e49c243bfbe4cd08cf82c41818))
+* **deps-dev:** bump eslint-plugin-react from 7.30.0 to 7.30.1 ([2199fd1](https://github.com/terrestris/shogun-gis-client/commit/2199fd144c9ec4e2f22ebe6ebcde85b03c9aeb41))
+* **deps-dev:** bump jest and @types/jest ([12170a6](https://github.com/terrestris/shogun-gis-client/commit/12170a65b545d6d577eae9556b300757d1c71bd7))
+* **deps-dev:** bump jest and @types/jest ([149b84d](https://github.com/terrestris/shogun-gis-client/commit/149b84da8539c612571465ba5100bd4eeb929afb))
+* **deps-dev:** bump jest-environment-jsdom from 28.1.0 to 28.1.1 ([8c072a5](https://github.com/terrestris/shogun-gis-client/commit/8c072a524b68498b79959699cb30ff4de5880a30))
+* **deps-dev:** bump jest-environment-jsdom from 28.1.1 to 28.1.2 ([1eba66a](https://github.com/terrestris/shogun-gis-client/commit/1eba66a4368cbb5e37e37c9c7f04930a7741b42a))
+* **deps-dev:** bump less from 4.1.2 to 4.1.3 ([24c3d9f](https://github.com/terrestris/shogun-gis-client/commit/24c3d9ffa019557e0746a2801729a19ab13f4eed))
+* **deps-dev:** bump mini-css-extract-plugin from 2.6.0 to 2.6.1 ([14000c8](https://github.com/terrestris/shogun-gis-client/commit/14000c8c81910c66e7afbf943cbb034d284b94ac))
+* **deps-dev:** bump react-refresh from 0.13.0 to 0.14.0 ([7c3a313](https://github.com/terrestris/shogun-gis-client/commit/7c3a313a1a1b3803e73433be48035b702b83107c))
+* **deps-dev:** bump semantic-release from 19.0.2 to 19.0.3 ([0cea4e5](https://github.com/terrestris/shogun-gis-client/commit/0cea4e584f8eefced85c9c1c24f821fe34d4c8b4))
+* **deps-dev:** bump terser-webpack-plugin from 5.3.1 to 5.3.3 ([a44a734](https://github.com/terrestris/shogun-gis-client/commit/a44a734cc85cc1aac2bcc17c3127031250817c03))
+* **deps-dev:** bump typescript from 4.7.2 to 4.7.3 ([12d04e6](https://github.com/terrestris/shogun-gis-client/commit/12d04e6f8fbc34c08976045fd7b9e678d527ba4c))
+* **deps-dev:** bump typescript from 4.7.3 to 4.7.4 ([283e13b](https://github.com/terrestris/shogun-gis-client/commit/283e13b4f5743acbc6244142f4a874adfe323850))
+* **deps-dev:** bump webpack from 5.72.1 to 5.73.0 ([72526f9](https://github.com/terrestris/shogun-gis-client/commit/72526f9e914d4b6aafa70298255625460d87a4db))
+* **deps-dev:** bump webpack-cli from 4.9.2 to 4.10.0 ([c6ed2fd](https://github.com/terrestris/shogun-gis-client/commit/c6ed2fd3ebe515c36c59037fa514c74f4c7699dd))
+* **deps-dev:** bump webpack-dev-server from 4.9.0 to 4.9.1 ([5860ef6](https://github.com/terrestris/shogun-gis-client/commit/5860ef6a946662911c039e7af0964bfa5b0438ab))
+* **deps-dev:** bump webpack-dev-server from 4.9.1 to 4.9.2 ([d36c8de](https://github.com/terrestris/shogun-gis-client/commit/d36c8de03e82ba2ce409f36436361ba7e4c8d4fe))
+* **deps-dev:** bump webpack-dev-server from 4.9.2 to 4.9.3 ([30573aa](https://github.com/terrestris/shogun-gis-client/commit/30573aa0dd914d12b55683e4c01636bad07e69a8))
+* **deps:** bump @reduxjs/toolkit from 1.8.2 to 1.8.3 ([927d53b](https://github.com/terrestris/shogun-gis-client/commit/927d53bf7f079de2d0811703999e027302289385))
+* **deps:** bump @terrestris/react-geo from 17.1.3 to 17.2.1 ([b485c4b](https://github.com/terrestris/shogun-gis-client/commit/b485c4bb461965b4072b0a8a6665391e732d8424))
+* **deps:** bump @terrestris/react-geo from 17.2.1 to 17.2.2 ([ed32d6a](https://github.com/terrestris/shogun-gis-client/commit/ed32d6ac60dd87bd02f11f1badd60001f343bf9c))
+* **deps:** bump @terrestris/react-geo from 17.2.2 to 17.3.0 ([8fbd893](https://github.com/terrestris/shogun-gis-client/commit/8fbd893f1da7e740b9ed4d14b2f10bf58423c2c2))
+* **deps:** bump @terrestris/react-geo from 17.3.0 to 17.3.1 ([559030e](https://github.com/terrestris/shogun-gis-client/commit/559030ed803cb64a2b7b82a15945fb443df77bf8))
+* **deps:** bump @terrestris/react-geo from 17.3.1 to 17.4.1 ([21ac106](https://github.com/terrestris/shogun-gis-client/commit/21ac1064d621bcac39d75cf488b50406b6cbe14e))
+* **deps:** bump @terrestris/shogun-util from 1.0.1 to 1.1.0 ([9dcb73e](https://github.com/terrestris/shogun-gis-client/commit/9dcb73e22e3111b582c53e12dabe396e7b3ee615))
+* **deps:** bump @terrestris/shogun-util from 1.1.0 to 1.2.1 ([d837f43](https://github.com/terrestris/shogun-gis-client/commit/d837f432a879c919cc6df5a3878cb7631340c7cd))
+* **deps:** bump @terrestris/shogun-util from 2.0.0 to 3.0.0 ([354fa96](https://github.com/terrestris/shogun-gis-client/commit/354fa96da4bf25d9081db49614e80706c1a7ce03))
+* **deps:** bump @terrestris/shogun-util from 3.0.0 to 3.1.2 ([d426116](https://github.com/terrestris/shogun-gis-client/commit/d42611606858028483f7adf192f31ac37a04c225))
+* **deps:** bump antd from 4.20.7 to 4.21.0 ([ecb4d02](https://github.com/terrestris/shogun-gis-client/commit/ecb4d028853192ce10ad024ccece6585edb682f6))
+* **deps:** bump antd from 4.21.0 to 4.21.1 ([3a379b3](https://github.com/terrestris/shogun-gis-client/commit/3a379b3f394b874ecec1586a0415e16634cbb904))
+* **deps:** bump antd from 4.21.1 to 4.21.3 ([5901460](https://github.com/terrestris/shogun-gis-client/commit/59014606f4df0b63c2c98651ecde9134e194dfe6))
+* **deps:** bump antd from 4.21.3 to 4.21.4 ([9f5e89c](https://github.com/terrestris/shogun-gis-client/commit/9f5e89c85919eec36f72726e1a89549923ff2cc1))
+* **deps:** bump antd from 4.21.4 to 4.21.5 ([9acb16a](https://github.com/terrestris/shogun-gis-client/commit/9acb16a5fdf8b920dd6399e5f2223390794fdee7))
+* **deps:** bump i18next from 21.8.10 to 21.8.11 ([b72ce14](https://github.com/terrestris/shogun-gis-client/commit/b72ce1449ad340f9ff679b6faabb2fbaef2a1ff2))
+* **deps:** bump i18next from 21.8.11 to 21.8.12 ([4a21c18](https://github.com/terrestris/shogun-gis-client/commit/4a21c18c88f0258e4be4031310445a1a85367070))
+* **deps:** bump i18next from 21.8.12 to 21.8.13 ([9b0014c](https://github.com/terrestris/shogun-gis-client/commit/9b0014c1a6c71b6368f92fd5de66309da351b56b))
+* **deps:** bump i18next from 21.8.5 to 21.8.8 ([bdf517c](https://github.com/terrestris/shogun-gis-client/commit/bdf517cfc8b10208f31839eb2f66389f16e32d08))
+* **deps:** bump i18next from 21.8.8 to 21.8.9 ([aabead9](https://github.com/terrestris/shogun-gis-client/commit/aabead959c86665e6a3fb57ad72187782feed572))
+* **deps:** bump i18next from 21.8.9 to 21.8.10 ([be13c25](https://github.com/terrestris/shogun-gis-client/commit/be13c25a67b77a93229b62281836798ca9de6331))
+* **deps:** bump react-i18next from 11.16.9 to 11.17.0 ([bdd6d6a](https://github.com/terrestris/shogun-gis-client/commit/bdd6d6aebff7d45d72e82e1885e15cec1b8af794))
+* **deps:** bump react-i18next from 11.17.0 to 11.17.1 ([e532b15](https://github.com/terrestris/shogun-gis-client/commit/e532b15216d5fc54978e256a31ef7d18e5c24553))
+* **deps:** bump react-i18next from 11.17.1 to 11.17.2 ([25113dc](https://github.com/terrestris/shogun-gis-client/commit/25113dcf12dd7c116c59c519556eca56c51b6eea))
+* **deps:** bump react-i18next from 11.17.2 to 11.17.3 ([2b7e28e](https://github.com/terrestris/shogun-gis-client/commit/2b7e28e0f095b5f6a504f6214130337c20f275df))
+* **deps:** bump react-i18next from 11.17.3 to 11.17.4 ([74c499b](https://github.com/terrestris/shogun-gis-client/commit/74c499bd314bfd610efcab138fce4926627021e8))
+* **deps:** bump react-i18next from 11.17.4 to 11.18.0 ([e14fcf3](https://github.com/terrestris/shogun-gis-client/commit/e14fcf3a4ddede21db867f99620208762a287f09))
+* update to the latest shogun-util ([e6ec46b](https://github.com/terrestris/shogun-gis-client/commit/e6ec46b958c3c02864a4120ec59d011302b7e004))
+* update translations ([9f40e8e](https://github.com/terrestris/shogun-gis-client/commit/9f40e8e5808036f7cca56f15b84bee092f1cccbe))
 
-### [3.1.1](https://github.com/terrestris/shogun-demo-client/compare/v3.1.0...v3.1.1) (2022-05-31)
+### [3.1.1](https://github.com/terrestris/shogun-gis-client/compare/v3.1.0...v3.1.1) (2022-05-31)
 
 
 ### Changes in layout
 
-* updates style of feature info ([4e7b1f7](https://github.com/terrestris/shogun-demo-client/commit/4e7b1f77af5d9c9110518faaf761d6821166f8b5))
-* updates style of print form ([1cbba36](https://github.com/terrestris/shogun-demo-client/commit/1cbba36fcd27e0ef0c3b4c0097126bbc547d9fad))
-* updates style of ToolMenu ([25e1392](https://github.com/terrestris/shogun-demo-client/commit/25e13925de490e6a172d08dc0dafe48812a620a3))
+* updates style of feature info ([4e7b1f7](https://github.com/terrestris/shogun-gis-client/commit/4e7b1f77af5d9c9110518faaf761d6821166f8b5))
+* updates style of print form ([1cbba36](https://github.com/terrestris/shogun-gis-client/commit/1cbba36fcd27e0ef0c3b4c0097126bbc547d9fad))
+* updates style of ToolMenu ([25e1392](https://github.com/terrestris/shogun-gis-client/commit/25e13925de490e6a172d08dc0dafe48812a620a3))
 
-## [3.1.0](https://github.com/terrestris/shogun-demo-client/compare/v3.0.0...v3.1.0) (2022-05-31)
+## [3.1.0](https://github.com/terrestris/shogun-gis-client/compare/v3.0.0...v3.1.0) (2022-05-31)
 
 
 ### Features
 
-* add addLayerModal ([34f3a4d](https://github.com/terrestris/shogun-demo-client/commit/34f3a4de84eefe488c3db644dce755230e6ffcdf))
+* add addLayerModal ([34f3a4d](https://github.com/terrestris/shogun-gis-client/commit/34f3a4de84eefe488c3db644dce755230e6ffcdf))
 
 
 ### Bugfixes
 
-* move locales to translation file and fix lint ([790f02e](https://github.com/terrestris/shogun-demo-client/commit/790f02ec14d45a7bdffccca91c94d809f680cd16))
+* move locales to translation file and fix lint ([790f02e](https://github.com/terrestris/shogun-gis-client/commit/790f02ec14d45a7bdffccca91c94d809f680cd16))
 
 
 ### Dependencies
 
-* remove TODO ([8ff0eb3](https://github.com/terrestris/shogun-demo-client/commit/8ff0eb3e212d5a8a9401c7aa70545be9d1de36aa))
+* remove TODO ([8ff0eb3](https://github.com/terrestris/shogun-gis-client/commit/8ff0eb3e212d5a8a9401c7aa70545be9d1de36aa))
 
-## [3.0.0](https://github.com/terrestris/shogun-demo-client/compare/v2.0.1...v3.0.0) (2022-05-31)
+## [3.0.0](https://github.com/terrestris/shogun-gis-client/compare/v2.0.1...v3.0.0) (2022-05-31)
 
 
 ### Features
 
-* add option to login into geoserver ([a519699](https://github.com/terrestris/shogun-demo-client/commit/a519699382db0ae34d86c449ddbb66c6a5bdb307))
-* introduce GeoServerUtil ([9a0321d](https://github.com/terrestris/shogun-demo-client/commit/9a0321d88cdb3781f6c29d7d4c5057756296b88d))
+* add option to login into geoserver ([a519699](https://github.com/terrestris/shogun-gis-client/commit/a519699382db0ae34d86c449ddbb66c6a5bdb307))
+* introduce GeoServerUtil ([9a0321d](https://github.com/terrestris/shogun-gis-client/commit/9a0321d88cdb3781f6c29d7d4c5057756296b88d))
 
 
 ### Breaking changes
 
-* change path of client config ([42fc794](https://github.com/terrestris/shogun-demo-client/commit/42fc7944303febb6b2da0dd31aeff94a7e908410))
+* change path of client config ([42fc794](https://github.com/terrestris/shogun-gis-client/commit/42fc7944303febb6b2da0dd31aeff94a7e908410))
 
 
 ### Dependencies
 
-* **deps-dev:** bump @typescript-eslint/eslint-plugin ([bff2460](https://github.com/terrestris/shogun-demo-client/commit/bff246097be6c9b393211c70ee25e00652033b54))
-* **deps-dev:** bump @typescript-eslint/parser from 5.26.0 to 5.27.0 ([3184238](https://github.com/terrestris/shogun-demo-client/commit/31842383220e118551efa997c8f82683f87c12a2))
-* **deps:** bump antd from 4.20.6 to 4.20.7 ([8c78b59](https://github.com/terrestris/shogun-demo-client/commit/8c78b590dbfd2d6b7d6b38918c463d7491d91fc5))
+* **deps-dev:** bump @typescript-eslint/eslint-plugin ([bff2460](https://github.com/terrestris/shogun-gis-client/commit/bff246097be6c9b393211c70ee25e00652033b54))
+* **deps-dev:** bump @typescript-eslint/parser from 5.26.0 to 5.27.0 ([3184238](https://github.com/terrestris/shogun-gis-client/commit/31842383220e118551efa997c8f82683f87c12a2))
+* **deps:** bump antd from 4.20.6 to 4.20.7 ([8c78b59](https://github.com/terrestris/shogun-gis-client/commit/8c78b590dbfd2d6b7d6b38918c463d7491d91fc5))
 
-### [2.0.1](https://github.com/terrestris/shogun-demo-client/compare/v2.0.0...v2.0.1) (2022-05-30)
+### [2.0.1](https://github.com/terrestris/shogun-gis-client/compare/v2.0.0...v2.0.1) (2022-05-30)
 
 
 ### Dependencies
 
-* **deps-dev:** bump @babel/core from 7.18.0 to 7.18.2 ([defb552](https://github.com/terrestris/shogun-demo-client/commit/defb552b3253daac6fc8fc78afa58b1482c7e5fd))
-* **deps-dev:** bump @babel/preset-env from 7.18.0 to 7.18.2 ([45e3fcc](https://github.com/terrestris/shogun-demo-client/commit/45e3fccec138775990b3897b1e719ddec51cb6f2))
-* **deps-dev:** bump @commitlint/cli from 17.0.0 to 17.0.1 ([1909399](https://github.com/terrestris/shogun-demo-client/commit/1909399f874b66eab489697dd4d37207b175e318))
-* **deps-dev:** bump typescript from 4.6.4 to 4.7.2 ([a5d3e43](https://github.com/terrestris/shogun-demo-client/commit/a5d3e4324474b9ca72e94b5ecbba79f39c101943))
-* **deps:** bump @reduxjs/toolkit from 1.8.1 to 1.8.2 ([0b0852e](https://github.com/terrestris/shogun-demo-client/commit/0b0852e93acfbed8142a78d12592c6b84c67a77f))
-* **deps:** bump i18next from 21.8.4 to 21.8.5 ([32dd20b](https://github.com/terrestris/shogun-demo-client/commit/32dd20bb519c3364dd0067f5968defedc9711979))
+* **deps-dev:** bump @babel/core from 7.18.0 to 7.18.2 ([defb552](https://github.com/terrestris/shogun-gis-client/commit/defb552b3253daac6fc8fc78afa58b1482c7e5fd))
+* **deps-dev:** bump @babel/preset-env from 7.18.0 to 7.18.2 ([45e3fcc](https://github.com/terrestris/shogun-gis-client/commit/45e3fccec138775990b3897b1e719ddec51cb6f2))
+* **deps-dev:** bump @commitlint/cli from 17.0.0 to 17.0.1 ([1909399](https://github.com/terrestris/shogun-gis-client/commit/1909399f874b66eab489697dd4d37207b175e318))
+* **deps-dev:** bump typescript from 4.6.4 to 4.7.2 ([a5d3e43](https://github.com/terrestris/shogun-gis-client/commit/a5d3e4324474b9ca72e94b5ecbba79f39c101943))
+* **deps:** bump @reduxjs/toolkit from 1.8.1 to 1.8.2 ([0b0852e](https://github.com/terrestris/shogun-gis-client/commit/0b0852e93acfbed8142a78d12592c6b84c67a77f))
+* **deps:** bump i18next from 21.8.4 to 21.8.5 ([32dd20b](https://github.com/terrestris/shogun-gis-client/commit/32dd20bb519c3364dd0067f5968defedc9711979))
 
 
 ### Bugfixes
 
-* fix color for scale ([e0be63e](https://github.com/terrestris/shogun-demo-client/commit/e0be63e4c6acc00a34876ed280912da631ebf847))
-* open print in new browser tab ([a975959](https://github.com/terrestris/shogun-demo-client/commit/a97595946d59bb987c933aa105b78a0750b59ebc))
+* fix color for scale ([e0be63e](https://github.com/terrestris/shogun-gis-client/commit/e0be63e4c6acc00a34876ed280912da631ebf847))
+* open print in new browser tab ([a975959](https://github.com/terrestris/shogun-gis-client/commit/a97595946d59bb987c933aa105b78a0750b59ebc))
 
-## [2.0.0](https://github.com/terrestris/shogun-demo-client/compare/v1.1.1...v2.0.0) (2022-05-24)
+## [2.0.0](https://github.com/terrestris/shogun-gis-client/compare/v1.1.1...v2.0.0) (2022-05-24)
 
 
 ### Breaking changes
 
-* implement handling for theming ([cd9f687](https://github.com/terrestris/shogun-demo-client/commit/cd9f6870df38bfe4c36d8326ca6e4ba915af3c6b))
+* implement handling for theming ([cd9f687](https://github.com/terrestris/shogun-gis-client/commit/cd9f6870df38bfe4c36d8326ca6e4ba915af3c6b))
 
 
 ### Bugfixes
 
-* catch undefined theme ([1bf523d](https://github.com/terrestris/shogun-demo-client/commit/1bf523d0663215a7c9a296455f39a14c0fb8fbac))
-* extract ConfigProvider from parseTheme ([5447e60](https://github.com/terrestris/shogun-demo-client/commit/5447e605439e6ac608c6ca32a88437ca3f01ce99))
+* catch undefined theme ([1bf523d](https://github.com/terrestris/shogun-gis-client/commit/1bf523d0663215a7c9a296455f39a14c0fb8fbac))
+* extract ConfigProvider from parseTheme ([5447e60](https://github.com/terrestris/shogun-gis-client/commit/5447e605439e6ac608c6ca32a88437ca3f01ce99))
 
-### [1.1.1](https://github.com/terrestris/shogun-demo-client/compare/v1.1.0...v1.1.1) (2022-05-24)
+### [1.1.1](https://github.com/terrestris/shogun-gis-client/compare/v1.1.0...v1.1.1) (2022-05-24)
 
-## [1.1.0](https://github.com/terrestris/shogun-demo-client/compare/v1.0.2...v1.1.0) (2022-05-24)
+## [1.1.0](https://github.com/terrestris/shogun-gis-client/compare/v1.0.2...v1.1.0) (2022-05-24)
 
 
 ### Features
 
-* introduce client configuration file (currently for the appPrefix only) ([7651fa0](https://github.com/terrestris/shogun-demo-client/commit/7651fa01495e960328e3c3020cf5feda8952fd1f))
+* introduce client configuration file (currently for the appPrefix only) ([7651fa0](https://github.com/terrestris/shogun-gis-client/commit/7651fa01495e960328e3c3020cf5feda8952fd1f))
 
 
 ### Bugfixes
 
-* provide empty clientConfig ([df63528](https://github.com/terrestris/shogun-demo-client/commit/df63528a376be4556b5ec75cbb4013c078d2705a))
-* remove fallback configration, make use of client's internal defaults instead ([dd04408](https://github.com/terrestris/shogun-demo-client/commit/dd044084433f46a9be5c7a32f5dc546338dcf158))
-* set correct default title ([4a455c2](https://github.com/terrestris/shogun-demo-client/commit/4a455c2fa372b622ab80868b6cff0c0d45288ff4))
+* provide empty clientConfig ([df63528](https://github.com/terrestris/shogun-gis-client/commit/df63528a376be4556b5ec75cbb4013c078d2705a))
+* remove fallback configration, make use of client's internal defaults instead ([dd04408](https://github.com/terrestris/shogun-gis-client/commit/dd044084433f46a9be5c7a32f5dc546338dcf158))
+* set correct default title ([4a455c2](https://github.com/terrestris/shogun-gis-client/commit/4a455c2fa372b622ab80868b6cff0c0d45288ff4))
 
-### [1.0.2](https://github.com/terrestris/shogun-demo-client/compare/v1.0.1...v1.0.2) (2022-05-24)
+### [1.0.2](https://github.com/terrestris/shogun-gis-client/compare/v1.0.1...v1.0.2) (2022-05-24)
 
 
 ### Changes in layout
 
-* adjust style for the gfi result layer ([716b326](https://github.com/terrestris/shogun-demo-client/commit/716b326fd8d9a1ad8e2bb8705b043e6e6de90e7e))
+* adjust style for the gfi result layer ([716b326](https://github.com/terrestris/shogun-gis-client/commit/716b326fd8d9a1ad8e2bb8705b043e6e6de90e7e))
 
 
 ### Bugfixes
 
-* i18n for usage hint ([a9d191b](https://github.com/terrestris/shogun-demo-client/commit/a9d191b58324e7e779d2b57b8972ae8f069bc0a8))
-* pass flat layers array to the CoordinateInfo ([34656f2](https://github.com/terrestris/shogun-demo-client/commit/34656f2829d3b8e0153a064d0e3e5e74d5e3d283))
+* i18n for usage hint ([a9d191b](https://github.com/terrestris/shogun-gis-client/commit/a9d191b58324e7e779d2b57b8972ae8f069bc0a8))
+* pass flat layers array to the CoordinateInfo ([34656f2](https://github.com/terrestris/shogun-gis-client/commit/34656f2829d3b8e0153a064d0e3e5e74d5e3d283))
 
-### [1.0.1](https://github.com/terrestris/shogun-demo-client/compare/v1.0.0...v1.0.1) (2022-05-24)
+### [1.0.1](https://github.com/terrestris/shogun-gis-client/compare/v1.0.0...v1.0.1) (2022-05-24)
 
 
 ### Dependencies
 
-* **deps-dev:** bump @typescript-eslint/eslint-plugin ([7eb64d4](https://github.com/terrestris/shogun-demo-client/commit/7eb64d40e9838d6207a4f2fa19e8f75d3a5acfed))
-* **deps-dev:** bump @typescript-eslint/parser from 5.25.0 to 5.26.0 ([faedbc0](https://github.com/terrestris/shogun-demo-client/commit/faedbc05ee3b9d5a30d97e93aa4de4d13f33f9e2))
-* **deps:** bump i18next from 21.8.3 to 21.8.4 ([da47779](https://github.com/terrestris/shogun-demo-client/commit/da477795382d4ce23556089a2c05f93eacdbdd92))
+* **deps-dev:** bump @typescript-eslint/eslint-plugin ([7eb64d4](https://github.com/terrestris/shogun-gis-client/commit/7eb64d40e9838d6207a4f2fa19e8f75d3a5acfed))
+* **deps-dev:** bump @typescript-eslint/parser from 5.25.0 to 5.26.0 ([faedbc0](https://github.com/terrestris/shogun-gis-client/commit/faedbc05ee3b9d5a30d97e93aa4de4d13f33f9e2))
+* **deps:** bump i18next from 21.8.3 to 21.8.4 ([da47779](https://github.com/terrestris/shogun-gis-client/commit/da477795382d4ce23556089a2c05f93eacdbdd92))
 
 
 ### Bugfixes
 
-* harmonize component signature by specifying the return type and passing through the rest props ([bffd8e7](https://github.com/terrestris/shogun-demo-client/commit/bffd8e7c5dcf972fe56887305b3317950854ac01))
+* harmonize component signature by specifying the return type and passing through the rest props ([bffd8e7](https://github.com/terrestris/shogun-gis-client/commit/bffd8e7c5dcf972fe56887305b3317950854ac01))
 
 ## 1.0.0 (2022-05-23)
 
 
 ### Features
 
-* init tool menu ([8e649c3](https://github.com/terrestris/shogun-demo-client/commit/8e649c33c92ceb109b476abd2fadfe0caf25ced3))
+* init tool menu ([8e649c3](https://github.com/terrestris/shogun-gis-client/commit/8e649c33c92ceb109b476abd2fadfe0caf25ced3))
 
 
 ### Changes in configuration
 
-* delete pre-push hook ([4d03878](https://github.com/terrestris/shogun-demo-client/commit/4d03878cd8217153079292c3d0fd23fdc06eaa4c))
-* fix directory for release workflow ([6cdb72b](https://github.com/terrestris/shogun-demo-client/commit/6cdb72b92e6f36866c61d3a4b6a6df192fd0de2e))
-* formatting ([f96fc9b](https://github.com/terrestris/shogun-demo-client/commit/f96fc9b783a432e36b92e48a42fa56f946bcd67f))
-* initialize release.yml ([e2c7c7c](https://github.com/terrestris/shogun-demo-client/commit/e2c7c7c7690bc461c4c15197f96123ff62cd0e39))
-* introduce commitlint ([38d4ce3](https://github.com/terrestris/shogun-demo-client/commit/38d4ce36d991e14d5758029708498a33a693eb2b))
-* introduce husky ([e9f9263](https://github.com/terrestris/shogun-demo-client/commit/e9f9263abd6b367d1242cd2d2d81f11ec55d2eef))
-* introduce semantic-release ([a2e4d41](https://github.com/terrestris/shogun-demo-client/commit/a2e4d41015e749d0af7af98fc3a910d02aa8f296))
+* delete pre-push hook ([4d03878](https://github.com/terrestris/shogun-gis-client/commit/4d03878cd8217153079292c3d0fd23fdc06eaa4c))
+* fix directory for release workflow ([6cdb72b](https://github.com/terrestris/shogun-gis-client/commit/6cdb72b92e6f36866c61d3a4b6a6df192fd0de2e))
+* formatting ([f96fc9b](https://github.com/terrestris/shogun-gis-client/commit/f96fc9b783a432e36b92e48a42fa56f946bcd67f))
+* initialize release.yml ([e2c7c7c](https://github.com/terrestris/shogun-gis-client/commit/e2c7c7c7690bc461c4c15197f96123ff62cd0e39))
+* introduce commitlint ([38d4ce3](https://github.com/terrestris/shogun-gis-client/commit/38d4ce36d991e14d5758029708498a33a693eb2b))
+* introduce husky ([e9f9263](https://github.com/terrestris/shogun-gis-client/commit/e9f9263abd6b367d1242cd2d2d81f11ec55d2eef))
+* introduce semantic-release ([a2e4d41](https://github.com/terrestris/shogun-gis-client/commit/a2e4d41015e749d0af7af98fc3a910d02aa8f296))
 
 
 ### Breaking changes
 
-* remove drawer and add toolMenu state ([ca735e3](https://github.com/terrestris/shogun-demo-client/commit/ca735e32257bed1f63fd00c06b8fbcdd2a34aa42))
-* remove unneeded components ([60111d6](https://github.com/terrestris/shogun-demo-client/commit/60111d63ca5491c2c9fe1acb40ec5ef018fff745))
+* remove drawer and add toolMenu state ([ca735e3](https://github.com/terrestris/shogun-gis-client/commit/ca735e32257bed1f63fd00c06b8fbcdd2a34aa42))
+* remove unneeded components ([60111d6](https://github.com/terrestris/shogun-gis-client/commit/60111d63ca5491c2c9fe1acb40ec5ef018fff745))
 
 
 ### Dependencies
 
-* add mapfish-print-manager ([c733467](https://github.com/terrestris/shogun-demo-client/commit/c733467e567bb94518c37da289332a19138536e8))
-* update react-geo ([6c1f11d](https://github.com/terrestris/shogun-demo-client/commit/6c1f11d46d36fdef27f1c26d984e1adff51c6c83))
-* update translations ([90efc61](https://github.com/terrestris/shogun-demo-client/commit/90efc617ae5fa67d9e563c16ce6352b79f0f8f30))
+* add mapfish-print-manager ([c733467](https://github.com/terrestris/shogun-gis-client/commit/c733467e567bb94518c37da289332a19138536e8))
+* update react-geo ([6c1f11d](https://github.com/terrestris/shogun-gis-client/commit/6c1f11d46d36fdef27f1c26d984e1adff51c6c83))
+* update translations ([90efc61](https://github.com/terrestris/shogun-gis-client/commit/90efc617ae5fa67d9e563c16ce6352b79f0f8f30))
 
 
 ### Bugfixes
 
-* fix tests ([2435825](https://github.com/terrestris/shogun-demo-client/commit/2435825193b5b044e2eaac3039c7a6ffd8fccc01))
-* show print tool ([fb06f91](https://github.com/terrestris/shogun-demo-client/commit/fb06f91a1b28689d7c3297c39fd9ccf7c5eeac43))
+* fix tests ([2435825](https://github.com/terrestris/shogun-gis-client/commit/2435825193b5b044e2eaac3039c7a6ffd8fccc01))
+* show print tool ([fb06f91](https://github.com/terrestris/shogun-gis-client/commit/fb06f91a1b28689d7c3297c39fd9ccf7c5eeac43))

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SHOGun demo client
+# SHOGun GIS client
 
 This repository contains the default WebGIS client used within the [SHOGun project](https://github.com/terrestris/shogun-docker).
 
@@ -6,7 +6,7 @@ The client was initialized with [create-react-geo-app](https://github.com/terres
 
 ## Installation 💾
 
-We recommended to install the client via the prebuilt Docker image `nexus.terrestris.de/repository/terrestris-public/shogun-demo-client`.
+We recommended to install the client via the prebuilt Docker image `nexus.terrestris.de/repository/terrestris-public/shogun-gis-client`.
 
 ## Usage 🖱️
 
@@ -15,7 +15,7 @@ If no ID is given (e.g. because no backend is available) or the requested applic
 
 ## Configuration 🎨
 
-Several global settings for the client can be configured via the [`gis-client-config.js`](https://github.com/terrestris/shogun-demo-client/blob/main/resources/config/gis-client-config.js) file:
+Several global settings for the client can be configured via the [`gis-client-config.js`](https://github.com/terrestris/shogun-gis-client/blob/main/resources/config/gis-client-config.js) file:
 
 | Name | Description | Default |
 | ---- | ----------- | ------- |
@@ -31,8 +31,8 @@ The configuration file is not bundled and will be loaded before application star
 ```yml
 version: '3.7'
 services:
-  shogun-demo-client:
-    image: nexus.terrestris.de/repository/terrestris-public/shogun-demo-client:latest
+  shogun-gis-client:
+    image: nexus.terrestris.de/repository/terrestris-public/shogun-gis-client:latest
     volumes:
       - ./gis-client-config.js:/usr/share/nginx/html/gis-client-config.js
     (…)
@@ -67,10 +67,10 @@ npm run build
 or directly included in an `nginx` based Docker image via:
 
 ```
-docker build -t shogun-demo-client:1.0.0 .
+docker build -t shogun-gis-client:1.0.0 .
 ```
 
-Run `docker run -p 80:80 shogun-demo-client:1.0.0` to start it locally.
+Run `docker run -p 80:80 shogun-gis-client:1.0.0` to start it locally.
 
 ## Contributing 💫
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "shogun-demo-client",
+  "name": "@terrestris/shogun-gis-client",
   "version": "3.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "shogun-demo-client",
+      "name": "@terrestris/shogun-gis-client",
       "version": "3.4.1",
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "shogun-demo-client",
+  "name": "@terrestris/shogun-gis-client",
   "version": "3.4.1",
-  "description": "This is a shogun demo client based on react-geo client template",
+  "description": "This is the default GIS client used in the SHOGun project. Based on the react-geo-client template",
   "keywords": [
     "shogun",
     "react",
@@ -11,7 +11,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:terrestris/shogun-demo-client.git"
+    "url": "git@github.com:terrestris/shogun-gis-client.git"
   },
   "license": "BSD-2-Clause",
   "author": "terrestris GmbH & Co. KG <info@terrestris.de>",


### PR DESCRIPTION
Since the repository contains not just a demo, but the default GIS client for the SHOGun backend, this suggests to rename the project to `@terrestris/shogun-gis-client`.

**Breaking:**

- All upcoming docker images will be named accordingly: `nexus.terrestris.de/repository/terrestris-public/shogun-gis-client`. Please adjust your images usages in docker-compose setups and deploy pipelines.
- The repository url will be changed to `https://github.com/terrestris/shogun-gis-client` after this PR has been merged. Even if GitHub provides a redirct, I would suggest to adjust your checkouts.

Please review @terrestris/devs.